### PR TITLE
Tweak copy on homepage

### DIFF
--- a/client/templates/home.html
+++ b/client/templates/home.html
@@ -5,9 +5,8 @@
     <p>Internet Monitor lets you explore, create, customize, and share
     dashboards of data visualizations about multiple facets of the Internet.</p>
     <div class="text-center">
-    <p>Click the "New Dashboard" button to get started.</p>
     <a class="btn btn-success btn-lg" href="{{ pathFor route='dashboards.new' }}">
-      New Dashboard
+      Get Started
     </a>
     </div>
   </div>


### PR DESCRIPTION
Removed some redundant language on the homepage. 

Previously:

![screen shot 2015-07-24 at 11 25 14 am](https://cloud.githubusercontent.com/assets/6515467/8878021/beba9046-31f6-11e5-972b-2be7b419bc43.png)

Now:

![screen shot 2015-07-24 at 11 25 59 am](https://cloud.githubusercontent.com/assets/6515467/8878029/c9cbeef8-31f6-11e5-9ec8-245c9b6b2ee6.png)
