### PR TITLE
change 'feed' to 'web feed'

### DIFF
--- a/packages/feed/client/widget.html
+++ b/packages/feed/client/widget.html
@@ -8,7 +8,7 @@
     {{ else }}
       <li>
         <p class="feed-no-feed">
-          Use this widget's settings (the gear icon above) to add a feed URL.
+          Use this widget's settings (the gear icon above) to add an RSS or Atom feed URL.
         </p>
       </li>
     {{/each}}

--- a/packages/feed/client/widget.js
+++ b/packages/feed/client/widget.js
@@ -10,7 +10,7 @@ Template.FeedWidget.onCreated(function() {
 
 Template.FeedWidget.helpers({
   widgetTitle: function() {
-    return this.title || 'Feed Items';
+    return this.title || 'Web Feed Items';
   },
   feedItems: function() {
     return FeedItems.find({ 'feed.url': this.feedUrl }, { sort: { date: -1 } });

--- a/packages/feed/feed.js
+++ b/packages/feed/feed.js
@@ -14,7 +14,7 @@ FeedWidget.prototype.constructor = FeedWidget;
 
 Feed = {
   widget: {
-    name: 'Feed',
+    name: 'Web Feed',
     description: 'Shows items from an RSS or Atom feed',
     dimensions: { width: 2, height: 3 },
     resize: { mode: 'reflow' },


### PR DESCRIPTION
Rename the Feed widget to "Web Feed" and edit the instructions that display when no feed has been added. Changes made to improve clarity based on user feedback.

![screen shot 2015-10-28 at 1 54 05 pm](https://cloud.githubusercontent.com/assets/6515467/10797939/6545700a-7d7b-11e5-82e2-1a6973721ea6.png)

![screen shot 2015-10-28 at 1 54 09 pm](https://cloud.githubusercontent.com/assets/6515467/10797941/6972265a-7d7b-11e5-9833-06c32bdf18b6.png)
