### PR TITLE
Change scatter widget's long names to short ones

### DIFF
--- a/packages/imon-scatter/client/settings.html
+++ b/packages/imon-scatter/client/settings.html
@@ -13,7 +13,7 @@
   </a>
   <select class="x-axis form-control" id="x-select" name="x-axis">
   {{# each indicators }}
-  <option value="{{ name }}" {{ isSelected name ../x.indicator }}>{{ name }}</option>
+  <option value="{{ id }}" {{ isSelected id ../x.indicator }}>{{ shortName }}</option>
   {{/each}}
   </select>
   <div class="row collapse" id="x-options">
@@ -38,7 +38,7 @@
   </a>
   <select class="y-axis form-control" id="y-select" name="y-axis">
   {{# each indicators }}
-  <option value="{{ name }}" {{ isSelected name ../y.indicator }}>{{ name }}</option>
+  <option value="{{ id }}" {{ isSelected id ../y.indicator }}>{{ shortName }}</option>
   {{/each}}
   </select>
   <div class="row collapse" id="y-options">

--- a/packages/imon-scatter/client/settings.js
+++ b/packages/imon-scatter/client/settings.js
@@ -3,7 +3,7 @@ Template.IMonScatterSettings.onCreated(function() {
 });
 
 Template.IMonScatterSettings.helpers({
-  indicators: function() { return IMonIndicators.find({}, { sort: { name: 1 }}); },
+  indicators: function() { return IMonIndicators.find({}, { sort: { shortName: 1 }}); },
   isSelected: function(a, b) { return a === b ? 'selected' : ''; },
   isChecked: function(val) { return val ? 'checked' : ''; },
 });
@@ -13,12 +13,12 @@ Template.IMonScatterSettings.events({
     var newData = {
       title: template.find('#chart-title').value,
       x: {
-        indicator: template.find('#x-select').value,
+        indicator: parseInt(template.find('#x-select').value),
         log: template.find('#x-log').checked,
         jitter: parseInt(template.find('#x-jitter').value)
       },
       y: {
-        indicator: template.find('#y-select').value,
+        indicator: parseInt(template.find('#y-select').value),
         log: template.find('#y-log').checked,
         jitter: parseInt(template.find('#y-jitter').value)
       }};

--- a/packages/imon-scatter/client/widget.js
+++ b/packages/imon-scatter/client/widget.js
@@ -5,7 +5,8 @@ Template.IMonScatterWidget.onCreated(function() {
       Template.currentData().x.indicator,
       Template.currentData().y.indicator
     ];
-    template.subscribe('imon_data', 'all', indicators,'name');
+    template.subscribe('imon_data', 'all', indicators,'id');
+    template.subscribe('imon_indicators');
     template.subscribe('imon_countries');
   });
 });
@@ -67,7 +68,8 @@ Template.IMonScatterWidget.onRendered(function() {
     if (!template.subscriptionsReady()) { return; }
     var xIndicator = Template.currentData().x.indicator;
     var yIndicator = Template.currentData().y.indicator;
-    var xTitle = xIndicator, yTitle = yIndicator;
+    var xTitle = IMonIndicators.findOne({ id: xIndicator }).shortName;
+    var yTitle = IMonIndicators.findOne({ id: yIndicator }).shortName; 
     if (Template.currentData().x.log) {
       xTitle = 'Log ' + xTitle;
     }
@@ -77,8 +79,8 @@ Template.IMonScatterWidget.onRendered(function() {
 
     var data = [];
     IMonCountries.find().forEach(function(country) {
-      var x = IMonData.findOne({ countryCode: country.code, name: xIndicator });
-      var y = IMonData.findOne({ countryCode: country.code, name: yIndicator });
+      var x = IMonData.findOne({ countryCode: country.code, sourceId: xIndicator });
+      var y = IMonData.findOne({ countryCode: country.code, sourceId: yIndicator });
       if (_.isUndefined(x) || _.isUndefined(y)) { return; }
 
       var xValue = x.value, yValue = y.value;

--- a/packages/imon-scatter/imon_scatter.js
+++ b/packages/imon-scatter/imon_scatter.js
@@ -11,12 +11,12 @@ Settings = {
   defaultData: {
     title: 'Scatter Plot',
     x: {
-      indicator: 'Percentage of individuals using the Internet',
+      indicator: 5, // Percentage of individuals using the Internet
       log: false,
       jitter: 0.0
     },
     y: {
-      indicator: 'Average download speed (kbps)',
+      indicator: 16, // Average download speed (kbps)
       log: false,
       jitter: 0.0
     }


### PR DESCRIPTION
In the imon-scatter package, changing the indicator keys to use ID's instead of long names in order to use short names on the widget as titles to the X and Y axes to avoid the long names/titles being cut off because of the widget width/height.
