### PR TITLE
imon-valuetrend widget

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -78,3 +78,4 @@ isotope:isotope
 useraccounts:bootstrap
 
 imon-speedometer
+imon-valuetrend

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -76,6 +76,7 @@ imon-data@0.0.1
 imon-percent@0.0.1
 imon-scatter@0.0.1
 imon-speedometer@0.0.1
+imon-valuetrend@0.0.1
 iron:controller@1.0.12
 iron:core@1.0.11
 iron:dynamic-template@1.0.12

--- a/packages/imon-data/imon-data.js
+++ b/packages/imon-data/imon-data.js
@@ -9,6 +9,7 @@ IMonCountries = new Mongo.Collection('imon_countries');
 IMonIndicators = new Mongo.Collection('imon_indicators');
 IMonDev = new Mongo.Collection('imon_dev');
 IMonCountriesDev = new Mongo.Collection('imon_dev_countries');
+IMonIndicatorsDev = new Mongo.Collection('imon_dev_indicators');
 
 IMonCountries.attachSchema(new SimpleSchema({
   name:        { type: String },
@@ -36,7 +37,6 @@ IMonIndicators.attachSchema(new SimpleSchema({
   id:            { type: Number, unique: true },
   name:          { type: String, unique: true },
   shortName:     { type: String, optional:true },
-  adminName:     { type: String, unique: true }, 
   description:   { type: String, optional:true },  
   displaySuffix: { type: String, optional:true },
   precision:     { type: Number, optional: true },
@@ -58,4 +58,14 @@ IMonCountriesDev.attachSchema(new SimpleSchema({
   code:         { type: String, unique: true },
   name:         { type: String },
   dataSources:  { type: [String], defaultValue: [] }
+}));
+
+IMonIndicatorsDev.attachSchema(new SimpleSchema({
+  id:           { type: Number, unique: true },
+  name:         { type: String, unique: true },
+  shortName:    { type: String, optional: true },
+  description:  { type: String, optional: true },
+  adminName:    { type: String, unique: true },
+  precision:    { type: Number, optional: true },
+  displayClass: { type: String, optional: true }
 }));

--- a/packages/imon-data/imon-data.js
+++ b/packages/imon-data/imon-data.js
@@ -7,9 +7,9 @@ Settings = {
 IMonData = new Mongo.Collection('imon_data');
 IMonCountries = new Mongo.Collection('imon_countries');
 IMonIndicators = new Mongo.Collection('imon_indicators');
-IMonDev = new Mongo.Collection('imon_dev');
-IMonCountriesDev = new Mongo.Collection('imon_dev_countries');
-IMonIndicatorsDev = new Mongo.Collection('imon_dev_indicators');
+IMonDev = new Mongo.Collection('imon_data_v2');
+IMonCountriesDev = new Mongo.Collection('imon_countries_v2');
+IMonIndicatorsDev = new Mongo.Collection('imon_indicators_v2');
 
 IMonCountries.attachSchema(new SimpleSchema({
   name:        { type: String },
@@ -67,5 +67,6 @@ IMonIndicatorsDev.attachSchema(new SimpleSchema({
   description:  { type: String, optional: true },
   adminName:    { type: String, unique: true },
   precision:    { type: Number, optional: true },
-  displayClass: { type: String, optional: true }
+  displayClass: { type: String, optional: true },
+  inverted:     { type: Boolean, optional: true }
 }));

--- a/packages/imon-data/imon-data.js
+++ b/packages/imon-data/imon-data.js
@@ -1,11 +1,7 @@
 Settings = {
   baseUrl: 'https://thenetmonitor.org',
   updateEvery: 1000 * 60 * 60 * 12 * 1,
-  timeout: 60 * 1000,
-  dev:{ // temp settings
-    getAll: false, // get all countries?
-    getCountries: ['usa', 'kor', 'mex'] // if not all
-  }
+  timeout: 60 * 1000
 };
 
 IMonData = new Mongo.Collection('imon_data');

--- a/packages/imon-data/imon-data.js
+++ b/packages/imon-data/imon-data.js
@@ -1,12 +1,18 @@
 Settings = {
   baseUrl: 'https://thenetmonitor.org',
   updateEvery: 1000 * 60 * 60 * 12 * 1,
-  timeout: 60 * 1000
+  timeout: 60 * 1000,
+  dev:{ // temp settings
+    getAll: false, // get all countries?
+    getCountries: ['usa', 'kor', 'mex'] // if not all
+  }
 };
 
 IMonData = new Mongo.Collection('imon_data');
 IMonCountries = new Mongo.Collection('imon_countries');
 IMonIndicators = new Mongo.Collection('imon_indicators');
+IMonDev = new Mongo.Collection('imon_dev');
+IMonCountriesDev = new Mongo.Collection('imon_dev_countries');
 
 IMonCountries.attachSchema(new SimpleSchema({
   name:        { type: String },
@@ -34,6 +40,7 @@ IMonIndicators.attachSchema(new SimpleSchema({
   id:            { type: Number, unique: true },
   name:          { type: String, unique: true },
   shortName:     { type: String, optional:true },
+  adminName:     { type: String, unique: true }, 
   description:   { type: String, optional:true },  
   displaySuffix: { type: String, optional:true },
   precision:     { type: Number, optional: true },
@@ -41,4 +48,18 @@ IMonIndicators.attachSchema(new SimpleSchema({
   max:           { type: Number, decimal: true, optional: true }, 
   sourceName:    { type: String },
   sourceUrl:     { type: String, regEx: SimpleSchema.RegEx.Url, optional: true}
+}));
+
+IMonDev.attachSchema(new SimpleSchema({
+  countryCode: { type: String, max: 3 },
+  imId:        { type: Number },
+  indAdminName:{ type: String, optional: true },
+  date:        { type: Date, optional: true },
+  value:       { type: Number, decimal: true, optional: true }
+}));
+
+IMonCountriesDev.attachSchema(new SimpleSchema({
+  code:         { type: String, unique: true },
+  name:         { type: String },
+  dataSources:  { type: [String], defaultValue: [] }
 }));

--- a/packages/imon-data/package.js
+++ b/packages/imon-data/package.js
@@ -21,6 +21,7 @@ Package.onUse(function(api) {
   api.export('IMonData');
   api.export('IMonDev');
   api.export('IMonCountriesDev');
+  api.export('IMonIndicatorsDev');
 });
 
 Npm.depends({ 'jsonapi-datastore': '0.3.2-beta' });

--- a/packages/imon-data/package.js
+++ b/packages/imon-data/package.js
@@ -19,6 +19,8 @@ Package.onUse(function(api) {
   api.export('IMonIndicators');
   api.export('IMonCountries');
   api.export('IMonData');
+  api.export('IMonDev');
+  api.export('IMonCountriesDev');
 });
 
 Npm.depends({ 'jsonapi-datastore': '0.3.2-beta' });

--- a/packages/imon-data/server/publications.js
+++ b/packages/imon-data/server/publications.js
@@ -18,8 +18,16 @@ Meteor.publish('imon_data', function(countryCode, indicatorIds, idField) {
   return IMonData.find(selector);
 });
 
-Meteor.publish('imon_dev', function(){
-  return IMonDev.find();
+Meteor.publish('imon_dev', function(countryCode, indicatorIds){ //indicatorIds: Array, countryCode: String
+  var selector = {};
+  if(_.isUndefined(countryCode) || _.isUndefined(indicatorIds)) { return; }
+  if (countryCode !== 'all') {
+    selector.countryCode = countryCode;
+  }
+  if(_.isArray(indicatorIds)){
+    selector.indAdminName = { $in: indicatorIds }; 
+  }
+  return IMonDev.find(selector);
 });
 
 Meteor.publish('imon_countries_dev', function(){

--- a/packages/imon-data/server/publications.js
+++ b/packages/imon-data/server/publications.js
@@ -34,6 +34,10 @@ Meteor.publish('imon_countries_dev', function(){
   return IMonCountriesDev.find();
 });
 
+Meteor.publish('imon_indicators_dev', function(){
+  return IMonIndicatorsDev.find();
+});
+
 function selectIndicators(indicatorIds,selector,idField){
   idField = idField === 'name' ? 'name' : 'sourceId';
   selector = selector ? selector : {};

--- a/packages/imon-data/server/publications.js
+++ b/packages/imon-data/server/publications.js
@@ -18,6 +18,10 @@ Meteor.publish('imon_data', function(countryCode, indicatorIds, idField) {
   return IMonData.find(selector);
 });
 
+Meteor.publish('imon_dev', function(){
+  return IMonDev.find();
+});
+
 function selectIndicators(indicatorIds,selector,idField){
   idField = idField === 'name' ? 'name' : 'sourceId';
   selector = selector ? selector : {};

--- a/packages/imon-data/server/publications.js
+++ b/packages/imon-data/server/publications.js
@@ -35,7 +35,7 @@ Meteor.publish('imon_countries_dev', function(){
 });
 
 Meteor.publish('imon_indicators_dev', function(){
-  return IMonIndicatorsDev.find();
+  return IMonIndicatorsDev.find({ id: { $nin: [32,33] } }); // all except Herdict & Morningside until there's data for them
 });
 
 function selectIndicators(indicatorIds,selector,idField){

--- a/packages/imon-data/server/publications.js
+++ b/packages/imon-data/server/publications.js
@@ -22,6 +22,10 @@ Meteor.publish('imon_dev', function(){
   return IMonDev.find();
 });
 
+Meteor.publish('imon_countries_dev', function(){
+  return IMonCountriesDev.find();
+});
+
 function selectIndicators(indicatorIds,selector,idField){
   idField = idField === 'name' ? 'name' : 'sourceId';
   selector = selector ? selector : {};

--- a/packages/imon-data/server/seed.js
+++ b/packages/imon-data/server/seed.js
@@ -28,11 +28,12 @@ function fetchData() {
 
 }
 
+
 function fetchDev(){
   console.log('IMonDev: Fetching country data...');
   var store = new Store();
   var futures = [];
-  var baseUrl = 'https://imon.dev.berkmancenter.org/v2/countries';
+  var baseUrl = 'https://thenetmonitor.org/v2/countries';
 
   var fut = HTTP.get.future()(baseUrl, { timeout: Settings.timeout*3 });
   futures.push(fut);
@@ -59,7 +60,7 @@ function fetchDevInd(){ // in separate function temporarily.
   console.log('IMonDev: Fetching indicator data...');
   var store = new Store();
   var futures = [];
-  var baseUrl = 'https://imon.dev.berkmancenter.org/v2/indicators';
+  var baseUrl = 'https://thenetmonitor.org/v2/indicators';
 
   var fut = HTTP.get.future()(baseUrl, { timeout: Settings.timeout });
   futures.push(fut);
@@ -253,7 +254,8 @@ function insertDevInd(ind){
     shortName: ind.short_name,
     description: ind.description,
     displayClass: ind.display_class,
-    precision: ind.precision
+    precision: ind.precision,
+    inverted: ind.inverted
   }
   try{
     IMonIndicatorsDev.upsert({ id: i.id }, { $set: i });

--- a/packages/imon-valuetrend/client/info.html
+++ b/packages/imon-valuetrend/client/info.html
@@ -1,0 +1,7 @@
+<template name="IMonValuetrendInfo">
+<p>
+  This widget displays the value of an indicator for a chosen country and its trend over time.s 
+</p>
+<hr />
+<p>The data backing this widget is made available through Internet Monitor, which aggregates and analyzes data from a wide range of sources. Information on each of the individual indicators is available on our <a href="https://thenetmonitor.org/sources" target="_blank" >Data Sources</a> page.</p>
+</template>

--- a/packages/imon-valuetrend/client/settings.html
+++ b/packages/imon-valuetrend/client/settings.html
@@ -16,6 +16,14 @@
   {{/each}}
   </select>
 </div>
+<div class="form-group">
+	<label for="color-select">Color</label>
+	<select class="color form-control" id="color-select" name="color">
+	{{# each colors }}
+		<option value="{{ code }}" {{ isSelected code ../color }}>{{ name }}</option>
+	{{/each}}
+	</select>
+</div>
 
 <button class="btn btn-primary save-settings">Save</button>
 {{ else }}

--- a/packages/imon-valuetrend/client/settings.html
+++ b/packages/imon-valuetrend/client/settings.html
@@ -1,0 +1,24 @@
+<template name="IMonValuetrendSettings">
+{{# if Template.subscriptionsReady }}
+<div class="form-group">
+	<label for="indicator-select">Indicator</label>
+	<select class="indicator form-control" id="indicator-select" name="indicator">
+	{{# each indicators }}
+		<option value="{{ adminName }}" {{ isSelected adminName ../indicatorName }}>{{ shortName }}</option>
+	{{/ each }}
+	</select>
+</div>
+<div class="form-group">
+  <label for="country-select">Country</label>
+  <select class="country form-control" id="country-select" name="country">
+  {{# each countries }}
+	<option value="{{ code }}" {{ isSelected code ../country }}>{{ name }}</option>
+  {{/each}}
+  </select>
+</div>
+
+<button class="btn btn-primary save-settings">Save</button>
+{{ else }}
+	{{ widgetLoading }}
+{{/if}}
+</template>

--- a/packages/imon-valuetrend/client/settings.js
+++ b/packages/imon-valuetrend/client/settings.js
@@ -1,0 +1,28 @@
+Template.IMonValuetrendSettings.onCreated(function(){
+  var template = this;
+  template.autorun(function(){
+    template.subscribe('imon_dev');
+    template.subscribe('imon_countries_dev');
+    template.subscribe('imon_indicators');
+  });
+});
+
+Template.IMonValuetrendSettings.helpers({
+  countries: function() { return IMonCountriesDev.find({}, { sort: { name: 1 } }); },
+  indicators: function() { return IMonIndicators.find({ adminName: { $nin: ['ONIco', 'ONIs', 'ONIp', 'ONIit', 'ONIcs', 'ONItr']}}, { sort: { shortName: 1 } }); },
+  isSelected: function(a, b) { return a == b ? 'selected' : ''; },
+});
+
+Template.IMonValuetrendSettings.events({
+  'click .save-settings': function(ev, template) {
+    var country = template.find('.country').value;
+    var ind = template.find('.indicator').value;
+    var newData = {
+      country: country,
+      indicatorName: ind
+    };
+    if(_.isUndefined(IMonDev.find({ countryCode: country, indAdminName: ind }))) { console.log("No data found!"); }
+    template.closeSettings();
+    this.set(newData);
+  }
+});

--- a/packages/imon-valuetrend/client/settings.js
+++ b/packages/imon-valuetrend/client/settings.js
@@ -1,7 +1,6 @@
 Template.IMonValuetrendSettings.onCreated(function(){
   var template = this;
   template.autorun(function(){
-    template.subscribe('imon_dev');
     template.subscribe('imon_countries_dev');
     template.subscribe('imon_indicators');
   });
@@ -31,7 +30,6 @@ Template.IMonValuetrendSettings.events({
       indicatorName: ind,
       color: color
     };
-    if(_.isUndefined(IMonDev.find({ countryCode: country, indAdminName: ind }))) { console.log("No data found!"); }
     template.closeSettings();
     this.set(newData);
   }

--- a/packages/imon-valuetrend/client/settings.js
+++ b/packages/imon-valuetrend/client/settings.js
@@ -2,13 +2,13 @@ Template.IMonValuetrendSettings.onCreated(function(){
   var template = this;
   template.autorun(function(){
     template.subscribe('imon_countries_dev');
-    template.subscribe('imon_indicators');
+    template.subscribe('imon_indicators_dev');
   });
 });
 
 Template.IMonValuetrendSettings.helpers({
   countries: function() { return IMonCountriesDev.find({}, { sort: { name: 1 } }); },
-  indicators: function() { return IMonIndicators.find({}, { sort: { shortName: 1 } }); },
+  indicators: function() { return IMonIndicatorsDev.find({}, { sort: { shortName: 1 } }); },
   isSelected: function(a, b) { return a == b ? 'selected' : ''; },
   colors: function() { 
     return [

--- a/packages/imon-valuetrend/client/settings.js
+++ b/packages/imon-valuetrend/client/settings.js
@@ -9,7 +9,7 @@ Template.IMonValuetrendSettings.onCreated(function(){
 
 Template.IMonValuetrendSettings.helpers({
   countries: function() { return IMonCountriesDev.find({}, { sort: { name: 1 } }); },
-  indicators: function() { return IMonIndicators.find({ adminName: { $nin: ['ONIco', 'ONIs', 'ONIp', 'ONIit', 'ONIcs', 'ONItr']}}, { sort: { shortName: 1 } }); },
+  indicators: function() { return IMonIndicators.find({}, { sort: { shortName: 1 } }); },
   isSelected: function(a, b) { return a == b ? 'selected' : ''; },
 });
 

--- a/packages/imon-valuetrend/client/settings.js
+++ b/packages/imon-valuetrend/client/settings.js
@@ -11,15 +11,25 @@ Template.IMonValuetrendSettings.helpers({
   countries: function() { return IMonCountriesDev.find({}, { sort: { name: 1 } }); },
   indicators: function() { return IMonIndicators.find({}, { sort: { shortName: 1 } }); },
   isSelected: function(a, b) { return a == b ? 'selected' : ''; },
+  colors: function() { 
+    return [
+      { code: '#6192BD', name: 'Blue' },
+      { code: '#2ca02c', name: 'Green' },
+      { code: '#f39c12', name: 'Orange' },
+      { code: '#c0392b', name: 'Red' }
+    ];
+  }
 });
 
 Template.IMonValuetrendSettings.events({
   'click .save-settings': function(ev, template) {
     var country = template.find('.country').value;
     var ind = template.find('.indicator').value;
+    var color = template.find('.color').value;
     var newData = {
       country: country,
-      indicatorName: ind
+      indicatorName: ind,
+      color: color
     };
     if(_.isUndefined(IMonDev.find({ countryCode: country, indAdminName: ind }))) { console.log("No data found!"); }
     template.closeSettings();

--- a/packages/imon-valuetrend/client/widget.css
+++ b/packages/imon-valuetrend/client/widget.css
@@ -1,0 +1,46 @@
+.imon-valuetrend h1 {
+  font-size:2em;
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.imon-valuetrend .title, .imon-valuetrend .current-data, .imon-valuetrend .current-value {
+  white-space: nowrap;
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.imon-valuetrend .current-value {
+  font-size: 4em;
+  line-height: 1em;
+}
+
+.imon-valuetrend .display-suffix{
+  font-size:0.4em;
+  opacity: 0.7;
+}
+
+.imon-valuetrend .value-label {
+  font-size: 0.9em;
+}
+.imon-valuetrend .trend-line {
+  display: inline-block;
+}
+.imon-valuetrend .trend-label {
+  font-size: 0.9em;
+}
+
+.imon-valuetrend .no-data {
+  padding: 1em;
+  font-size: 14px;
+}
+
+.imon-valuetrend .epoch.chart {
+  height: 45px;
+}
+
+.imon-valuetrend .epoch.chart .line {
+  stroke-width: 1.5px;
+  stroke: #2ca02c;
+}

--- a/packages/imon-valuetrend/client/widget.css
+++ b/packages/imon-valuetrend/client/widget.css
@@ -36,6 +36,10 @@
   font-size: 14px;
 }
 
+.imon-valuetrend .one-data{
+  font-size:1em;
+}
+
 .imon-valuetrend .epoch.chart {
   height: 45px;
 }

--- a/packages/imon-valuetrend/client/widget.html
+++ b/packages/imon-valuetrend/client/widget.html
@@ -1,0 +1,25 @@
+<template name="IMonValuetrendWidget">
+{{# if Template.subscriptionsReady }}
+<div class="title row">
+  <div class="col-xs-12"><h1>{{ indicator }}</h1></div>
+  <div class="col-xs-12"><h2>{{ countryName }}</h2></div>
+</div>
+{{/if}}
+<div class="current-data row">
+  <div class="current text-center col-xs-7">
+  {{# if Template.subscriptionsReady }}
+    {{# if currentValue }}
+      <div class="current-value">{{{ currentValue }}}</div>
+    {{ else }}
+      <div class="no-data">No data available.</div>
+    {{/if}}
+  {{/if}}
+  </div>
+  <div class="trend-line col-xs-5">
+    <div class="epoch chart" id="chart"></div>
+    {{# if Template.subscriptionsReady }}
+    <div class="trend-label text-center">{{ trendLabel }}</div>
+    {{/if}}
+  </div>
+</div>
+</template>

--- a/packages/imon-valuetrend/client/widget.html
+++ b/packages/imon-valuetrend/client/widget.html
@@ -15,10 +15,10 @@
     {{/if}}
   {{/if}}
   </div>
-  <div class="trend-line col-xs-5">
+  <div class="trend-line col-xs-5  text-center">
     <div class="epoch chart" id="chart"></div>
     {{# if Template.subscriptionsReady }}
-    <div class="trend-label text-center">{{ trendLabel }}</div>
+    <div class="trend-label">{{ trendLabel }}</div>
     {{/if}}
   </div>
 </div>

--- a/packages/imon-valuetrend/client/widget.js
+++ b/packages/imon-valuetrend/client/widget.js
@@ -1,0 +1,117 @@
+Template.IMonValuetrendWidget.onCreated(function() {
+  var template = this;
+  template.autorun(function() {
+    template.subscribe('imon_dev');
+    template.subscribe('imon_countries_dev');
+    template.subscribe('imon_indicators');
+  });
+});
+
+Template.IMonValuetrendWidget.helpers({
+  countryName: function() { return IMonCountriesDev.findOne({ code: Template.currentData().country }).name; },
+  indicator: function() { return IMonIndicators.findOne({ adminName: Template.currentData().indicatorName }).shortName; },
+  currentValue: function() {
+    var max = new Date("1000");
+    var val = 0;
+    var found = false;
+    IMonDev.find({ 
+      countryCode: Template.currentData().country,
+      indAdminName: Template.currentData().indicatorName 
+    }).forEach(function(d){
+      found = true;
+      if(d.date.getTime() > max.getTime()){
+        max = d.date;
+        val = d.value;
+      }
+    });
+    val = val >= 1000000 ? (Math.round(val/1000000*100)/100).toLocaleString() + 'M' : (Math.round(val * 100) / 100).toLocaleString();
+    var suffix = IMonIndicators.findOne({ adminName: Template.currentData().indicatorName }).displaySuffix;
+    val = suffix ? val + '<span class="display-suffix">' + suffix  + '</span>' : val;
+    return found ? val : '<p class="no-data"> No data found.</p>';
+  },
+  trendLabel: function() {
+    var min = new Date("9999");
+    var max = new Date("1000");
+    var i = 0;
+    IMonDev.find({
+      countryCode: Template.currentData().country,
+      indAdminName: Template.currentData().indicatorName
+    }).forEach(function(d){
+      i++;
+      if(d.date.getTime() > max.getTime()) max = d.date;
+      if(d.date.getTime() < min.getTime()) min = d.date;
+    });
+    var minYear = min.getFullYear();
+    var maxYear = max.getFullYear();
+    if(minYear === maxYear){
+      return i>1 && !allEqual([min.getTime(),max.getTime()]) ? 'From ' + Settings.months[min.getMonth()] + ' to ' + Settings.months[max.getMonth()] + ' ' + minYear : '';
+    }
+    else{
+      return i>1 && !allEqual([min.getTime(),max.getTime()]) ? 'From ' + minYear + ' to ' + maxYear : '';
+    }
+  }
+});
+
+Template.IMonValuetrendWidget.onRendered(function() {
+  var template = this;
+  var hideGraph = function($graph) {
+    $(template.find('svg')).hide();
+    if ($(template.find('.no-data')).length === 0) {
+      $($graph).append('<p class="no-data">No trend data available.</p>');
+    }
+  };
+
+  template.autorun(function() {
+    if (!template.subscriptionsReady()) { return; }
+    var cachedIndicator = Template.currentData().indicator;
+    var currId = Template.currentData().indicatorName; 
+    if(!cachedIndicator || cachedIndicator.adminName !== currId){
+      Template.currentData().set({ indicator: IMonIndicators.findOne({ adminName: currId })});
+    }
+
+    var graph = template.find('#chart');
+
+    var points = [];
+    var data = IMonDev.find({ 
+      countryCode: Template.currentData().country, 
+      indAdminName: Template.currentData().indicatorName }, { sort: { date: 1 } }).forEach(function(d){
+        var temp = {
+          x: d.date.getTime(),
+          y: parseInt(d.value)
+        };
+        points.push(temp);
+      });
+    if (points.length<2 || allEqual(_.pluck(points, 'x'))) {
+      hideGraph(graph);
+      return;
+    } else {
+      $(template.find('.no-data')).remove();
+      $(template.find('svg')).show();
+    }
+
+    pnts = [ { label: Template.currentData().indicatorName, values: points } ];
+
+    if (template.graph) {
+      template.graph.update(pnts);
+    } else {
+      template.graph = $(graph).epoch({
+        type: 'line',
+        data: pnts,
+        axes: [],
+        margins: { left: 0, right: 0, top: 3, bottom: 3 },
+      });
+    }
+  });
+});
+
+function allEqual(results){
+  var x = results[0];
+  var equal = true;
+  for(var i=0; i<results.length; i++){
+    if(results[i] != x){
+      equal = false;
+      break;
+    }
+  }
+  return equal;
+}

--- a/packages/imon-valuetrend/client/widget.js
+++ b/packages/imon-valuetrend/client/widget.js
@@ -59,7 +59,8 @@ Template.IMonValuetrendWidget.onRendered(function() {
   var showDate = function(ms, graph){
     var toDate = new Date(ms);
     var toYear = toDate.getFullYear();
-    $(graph).html('<p class="no-data one-data" title="No trend data available.">From ' + toYear + '</p>');
+    $(template.find('svg')).hide();
+    $(graph).append('<p class="no-data one-data" title="No trend data available.">From ' + toYear + '</p>');
   }
 
   template.autorun(function() {
@@ -75,6 +76,7 @@ Template.IMonValuetrendWidget.onRendered(function() {
     var graph = template.find('#chart');
 
     var points = [];
+
     var data = IMonDev.find({ 
       countryCode: Template.currentData().country, 
       indAdminName: Template.currentData().indicatorName }, { sort: { date: 1 } }).forEach(function(d){
@@ -84,12 +86,18 @@ Template.IMonValuetrendWidget.onRendered(function() {
         };
         points.push(temp);
       });
-    if (points.length<2 || allEqual(_.pluck(points, 'x'))) {
-      if(points.length>0)
-        showDate(points[0].x, graph);
+
+    if(points.length>0 && (points.length<2 || allEqual(_.pluck(points, 'x')))){ // has data but not enough for a trend line
+      showDate(points[0].x, graph);
       return;
-    } else {
-      $(template.findAll('.no-data')).remove();
+    }
+    else if(points.length === 0){ // does not have data at all
+      $(template.findAll('.one-data')).remove();
+      $(template.find('svg')).hide();
+      return;
+    }
+    else{
+      $(template.findAll('.one-data')).remove();
       $(template.find('svg')).show();
     }
 
@@ -113,7 +121,7 @@ function allEqual(results){
   var x = results[0];
   var equal = true;
   for(var i=0; i<results.length; i++){
-    if(results[i] != x){
+    if(results[i] !== x){
       equal = false;
       break;
     }

--- a/packages/imon-valuetrend/client/widget.js
+++ b/packages/imon-valuetrend/client/widget.js
@@ -101,6 +101,7 @@ Template.IMonValuetrendWidget.onRendered(function() {
         margins: { left: 0, right: 0, top: 3, bottom: 3 },
       });
     }
+    $(template.find('.line')).css('stroke', Template.currentData().color);
   });
 });
 

--- a/packages/imon-valuetrend/client/widget.js
+++ b/packages/imon-valuetrend/client/widget.js
@@ -1,7 +1,7 @@
 Template.IMonValuetrendWidget.onCreated(function() {
   var template = this;
   template.autorun(function() {
-    template.subscribe('imon_dev');
+    template.subscribe('imon_dev', Template.currentData().country, [ Template.currentData().indicatorName ]);
     template.subscribe('imon_countries_dev');
     template.subscribe('imon_indicators');
   });

--- a/packages/imon-valuetrend/client/widget.js
+++ b/packages/imon-valuetrend/client/widget.js
@@ -55,12 +55,12 @@ Template.IMonValuetrendWidget.helpers({
 
 Template.IMonValuetrendWidget.onRendered(function() {
   var template = this;
-  var hideGraph = function($graph) {
-    $(template.find('svg')).hide();
-    if ($(template.find('.no-data')).length === 0) {
-      $($graph).append('<p class="no-data">No trend data available.</p>');
-    }
-  };
+  
+  var showDate = function(ms, graph){
+    var toDate = new Date(ms);
+    var toYear = toDate.getFullYear();
+    $(graph).html('<p class="no-data one-data" title="No trend data available.">From ' + toYear + '</p>');
+  }
 
   template.autorun(function() {
     if (!template.subscriptionsReady()) { return; }
@@ -85,10 +85,11 @@ Template.IMonValuetrendWidget.onRendered(function() {
         points.push(temp);
       });
     if (points.length<2 || allEqual(_.pluck(points, 'x'))) {
-      hideGraph(graph);
+      if(points.length>0)
+        showDate(points[0].x, graph);
       return;
     } else {
-      $(template.find('.no-data')).remove();
+      $(template.findAll('.no-data')).remove();
       $(template.find('svg')).show();
     }
 

--- a/packages/imon-valuetrend/imon_valuetrend.js
+++ b/packages/imon-valuetrend/imon_valuetrend.js
@@ -2,7 +2,8 @@ Settings = {
   months: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
   defaultData: {
    country: 'usa',
-   indicatorName: 'hhnet'
+   indicatorName: 'hhnet',
+   color: '#2ca02c'
  }
 };
 

--- a/packages/imon-valuetrend/imon_valuetrend.js
+++ b/packages/imon-valuetrend/imon_valuetrend.js
@@ -1,0 +1,33 @@
+Settings = {
+  months: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+  defaultData: {
+   country: 'usa',
+   indicatorName: 'hhnet'
+ }
+};
+
+IMonValuetrendWidget = function(doc) {
+  Widget.call(this, doc);
+  _.defaults(this.data, Settings.defaultData);
+};
+
+IMonValuetrendWidget.prototype = Object.create(Widget.prototype);
+IMonValuetrendWidget.prototype.constructor = IMonValuetrendWidget;
+
+
+IMonValuetrend = {
+  widget: {
+    name: 'Value-Trend',
+    description: 'Shows value of an indicator for a specific country and its trend over time.',
+    url: 'https://thenetmonitor.org/sources',
+    dimensions: { width: 3, height: 1 },
+    constructor: IMonValuetrendWidget,
+    typeIcon: 'line-chart',
+    resize: { mode: 'cover', constraints: { height: { max: 1 } } }
+  },
+  org: {
+    name: 'Internet Monitor',
+    shortName: 'IM',
+    url: 'http://thenetmonitor.org'
+  }
+};

--- a/packages/imon-valuetrend/imon_valuetrend.js
+++ b/packages/imon-valuetrend/imon_valuetrend.js
@@ -1,5 +1,9 @@
 Settings = {
   months: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+  suffix: {
+    percentage: '%',
+    speed: 'kbps'
+  },
   defaultData: {
    country: 'usa',
    indicatorName: 'hhnet',

--- a/packages/imon-valuetrend/package.js
+++ b/packages/imon-valuetrend/package.js
@@ -1,0 +1,25 @@
+Package.describe({
+  name: 'imon-valuetrend',
+  version: '0.0.1',
+  summary: '',
+  git: ''
+});
+
+Package.onUse(function(api) {
+  api.versionsFrom('1.1.0.3');
+
+  api.use(['widget', 'underscore', 'momentjs:moment', 'imon-data']);
+  api.use(['templating', 'd3js:d3','epoch'], 'client');
+
+  api.addFiles('imon_valuetrend.js');
+  api.addFiles([
+    'client/info.html',
+    'client/settings.html',
+    'client/settings.js',
+    'client/widget.html',
+    'client/widget.js',
+    'client/widget.css'
+  ], 'client');
+
+  api.export('IMonValuetrend');
+});

--- a/widgets.js
+++ b/widgets.js
@@ -24,6 +24,7 @@ ActiveWidgets = [
   'imon-barchart',
   'imon-percent',
   'imon-speedometer',
+  'imon-valuetrend',
   'gsma-prepaid',
   'gsma-3g',
   'gsma-4g',


### PR DESCRIPTION
A widget that displays the most recent value of an indicator for a certain country and the trend of the historical data for this indicator + country if such data is available.

At this point:
- User can choose any indicator  + country from the settings.
- The value displayed is the most recent collected value.
- If there's no historical data, or all the data available is on the exact same date/time (can happen if only the year is provided, for example), no trend line is drawn/a "No trend data available." error is shown.
- The data (country and historical data) is fetched from the /v2/ dev API into separate 'dev' Mongo collections (IMonDev, and IMonCountriesDev) so no other widgets are affected. The indicator data is fetched from IMonIndicators as, until now, "no new attributes have been added to the indicators".
