### PR TITLE
Ability to animate over historical data in imon-choropleth

### DIFF
--- a/packages/imon-bubblechart/client/widget.js
+++ b/packages/imon-bubblechart/client/widget.js
@@ -83,7 +83,6 @@ Template.IMonBubbleChartWidget.onRendered(function() {
     if(i!==c.length){
       var playing = Meteor.setTimeout(function(){ play(i, options); }, 1000);
       $('#pause-button', buttonPlace).one('click', function(){
-        console.log('.');
         Meteor.clearTimeout(playing);
         $(this).hide();
         $('#play-button', buttonPlace).show();

--- a/packages/imon-choropleth/client/settings.html
+++ b/packages/imon-choropleth/client/settings.html
@@ -9,6 +9,11 @@
   {{/each}}
   </select>
 </div>
+<div class="form-group">
+	<div class="checkbox checkbox-success checkbox-small">
+          <input type="checkbox" id="animate" class="animate" value="yes" {{ isAnimated }}><label for="animate" title="Unchecking this displays the most recent collected data for every country regardless of year" >Animate and display historical data</label>
+    </div>
+</div>
 
 <button class="btn btn-primary save-settings">Save</button>
 {{ else }}

--- a/packages/imon-choropleth/client/settings.html
+++ b/packages/imon-choropleth/client/settings.html
@@ -9,11 +9,6 @@
   {{/each}}
   </select>
 </div>
-<div class="form-group">
-	<div class="checkbox checkbox-success checkbox-small">
-          <input type="checkbox" id="animate" class="animate" value="yes" {{ isAnimated }}><label for="animate" title="Unchecking this displays the most recent collected data for every country regardless of year" >Animate and display historical data</label>
-    </div>
-</div>
 
 <button class="btn btn-primary save-settings">Save</button>
 {{ else }}

--- a/packages/imon-choropleth/client/settings.js
+++ b/packages/imon-choropleth/client/settings.js
@@ -5,16 +5,14 @@ Template.IMonChoroplethSettings.onCreated(function() {
 Template.IMonChoroplethSettings.helpers({
   indicator: function() {  return IMonIndicators.findOne({adminName:Template.currentData().indicatorName});},
   indicators: function() { return IMonIndicators.find({}, { sort: { shortName: 1 }}); },
-  isSelected: function(a, b) { return a === b ? 'selected' : ''; },
-  isAnimated: function(){ return Template.currentData().animate ? 'checked' : ''; }
+  isSelected: function(a, b) { return a === b ? 'selected' : ''; }
 });
 
 Template.IMonChoroplethSettings.events({
   'click .save-settings': function(ev, template) {
     var indicatorName = template.find('.indicator').value;
     this.set({ 
-    	indicatorName: indicatorName,
-    	animate: template.find('#animate').checked
+    	indicatorName: indicatorName
     });
     template.closeSettings();
   }

--- a/packages/imon-choropleth/client/settings.js
+++ b/packages/imon-choropleth/client/settings.js
@@ -5,13 +5,17 @@ Template.IMonChoroplethSettings.onCreated(function() {
 Template.IMonChoroplethSettings.helpers({
   indicator: function() {  return IMonIndicators.findOne({adminName:Template.currentData().indicatorName});},
   indicators: function() { return IMonIndicators.find({}, { sort: { shortName: 1 }}); },
-  isSelected: function(a, b) { return a === b ? 'selected' : ''; }
+  isSelected: function(a, b) { return a === b ? 'selected' : ''; },
+  isAnimated: function(){ return Template.currentData().animate ? 'checked' : ''; }
 });
 
 Template.IMonChoroplethSettings.events({
   'click .save-settings': function(ev, template) {
     var indicatorName = template.find('.indicator').value;
-    this.set({ indicatorName: indicatorName });
+    this.set({ 
+    	indicatorName: indicatorName,
+    	animate: template.find('#animate').checked
+    });
     template.closeSettings();
   }
 });

--- a/packages/imon-choropleth/client/widget.css
+++ b/packages/imon-choropleth/client/widget.css
@@ -13,6 +13,23 @@
   border: none;
 }
 
+.imon-choropleth .checkmark, .imon-choropleth .checkmark-bg{
+	font-size:0.6em;
+}
+.imon-choropleth .animation-button .checkmark-bg{
+	margin-left:-0.5em;
+	color:white;
+}
+.imon-choropleth .animation-button .checkmark{
+	margin-left:-0.85em;
+	color:#27ae60;
+}
+.imon-choropleth #loop-enabled.hidden{
+	display:none;
+}
+.imon-choropleth #loop-enabled.shown{
+	display:inline;
+}
 .imon-choropleth .country{
 	transition-duration: 0.5s;
 }
@@ -22,7 +39,7 @@
   margin-bottom:0;
   margin-top:0;
 }
-.imon-choropleth .animation-button:disabled{
+.imon-choropleth .animation-button:disabled, .imon-choropleth .animation-button:disabled #loop-enabled .checkmark{
   cursor: not-allowed;
   color: #bdc3c7;
 }

--- a/packages/imon-choropleth/client/widget.css
+++ b/packages/imon-choropleth/client/widget.css
@@ -1,7 +1,9 @@
 .imon-choropleth .country {
   stroke: white;
 }
-
+.imon-choropleth h1{
+	min-height: 2em;
+}
 .imon-choropleth .choropleth-button{
 	float: right;
 	margin-top:-1.8em;

--- a/packages/imon-choropleth/client/widget.css
+++ b/packages/imon-choropleth/client/widget.css
@@ -2,6 +2,31 @@
   stroke: white;
 }
 
+.imon-choropleth .choropleth-button{
+	float: right;
+	margin-top:-1.8em;
+}
+.imon-choropleth .animation-button{
+  display: none;
+  background-color: transparent;
+  font-size:1.8em;
+  border: none;
+}
+
+.imon-choropleth .country{
+	transition-duration: 0.5s;
+}
+
+.imon-choropleth .choropleth-year h2{
+  display: inline;
+  margin-bottom:0;
+  margin-top:0;
+}
+.imon-choropleth .animation-button:disabled{
+  cursor: not-allowed;
+  color: #bdc3c7;
+}
+
 .indicator_name {
 
 }

--- a/packages/imon-choropleth/client/widget.html
+++ b/packages/imon-choropleth/client/widget.html
@@ -6,10 +6,11 @@
      <div class="choropleth-year"><h2>{{year}}</h2></div>
   {{/unless}}
   <div class="choropleth-button">
-    <button class="animation-button" id="step-backward-button"><i class="fa fa-backward"></i></button>
-    <button class="animation-button" id="play-button"><i class="fa fa-play-circle"></i></button>
-    <button class="animation-button" id="pause-button"><i class="fa fa-pause-circle"></i></button>
-    <button class="animation-button" id="step-forward-button"><i class="fa fa-forward"></i></button>
+    <button class="animation-button" id="step-backward-button" title="Step Backward"><i class="fa fa-backward"></i></button>
+    <button class="animation-button" id="loop-button" title="Loop"><i class="fa fa-retweet"></i><span id="loop-enabled" class="{{ isLooping }}"><i class="fa fa-circle checkmark-bg"></i><i class="fa fa-check-circle checkmark"></i></span></button>
+    <button class="animation-button" id="play-button" title="Play"><i class="fa fa-play-circle"></i></button>
+    <button class="animation-button" id="pause-button" title="Pause"><i class="fa fa-pause-circle"></i></button>
+    <button class="animation-button" id="step-forward-button" title="Step Forward"><i class="fa fa-forward"></i></button>
   </div>
   <div class="imon-choropleth-data imon-choropleth"></div>
 </template>

--- a/packages/imon-choropleth/client/widget.html
+++ b/packages/imon-choropleth/client/widget.html
@@ -2,6 +2,14 @@
   <h1 class="indicator_name"></h1>
   {{# unless Template.subscriptionsReady }}
     {{ widgetLoading }}
+    {{else}}
+     <div class="choropleth-year"><h2>{{year}}</h2></div>
   {{/unless}}
+  <div class="choropleth-button">
+    <button class="animation-button" id="step-backward-button"><i class="fa fa-backward"></i></button>
+    <button class="animation-button" id="play-button"><i class="fa fa-play-circle"></i></button>
+    <button class="animation-button" id="pause-button"><i class="fa fa-pause-circle"></i></button>
+    <button class="animation-button" id="step-forward-button"><i class="fa fa-forward"></i></button>
+  </div>
   <div class="imon-choropleth-data imon-choropleth"></div>
 </template>

--- a/packages/imon-choropleth/client/widget.js
+++ b/packages/imon-choropleth/client/widget.js
@@ -4,9 +4,6 @@ Template.IMonChoroplethWidget.onCreated(function() {
     template.subscribe('imon_indicators');
     template.subscribe('imon_indicators_v2');
     template.subscribe('imon_countries_v2');
-    if(Template.currentData().indicatorName){
-      template.subscribe('imon_data_v2', 'all', Template.currentData().indicatorName, !Template.currentData().animate);
-    }
   });
 });
 

--- a/packages/imon-choropleth/client/widget.js
+++ b/packages/imon-choropleth/client/widget.js
@@ -4,6 +4,9 @@ Template.IMonChoroplethWidget.onCreated(function() {
     template.subscribe('imon_indicators');
     template.subscribe('imon_indicators_v2');
     template.subscribe('imon_countries_v2');
+    // Even though data is arranged and sent as an array from the server, this is needed because IMonRecent updates with new subs as opposed to seeding
+    // so to make sure the latest data is fetched/used for these indicators, we must sub.
+    if(!Template.currentData().animate) template.subscribe('imon_data_v2', 'all', Template.currentData().indicatorName, true);
   });
 });
 

--- a/packages/imon-choropleth/client/widget.js
+++ b/packages/imon-choropleth/client/widget.js
@@ -14,6 +14,10 @@ Template.IMonChoroplethWidget.helpers({
   year: function(){ 
     var id = Template.instance().data.widget._id;
     return Template.currentData().animate && Session.get(id+'-array') ? Session.get(id+'-array')[Session.get(id+'-current')] : '';
+  },
+  isLooping: function(){
+    var id = Template.instance().data.widget._id;
+    return Session.get(id+'-loop') ? 'shown' : 'hidden';
   }
 });
 
@@ -253,8 +257,10 @@ Template.IMonChoroplethWidget.onRendered(function() {
 
         draw(false, arr[i], currentData, !iterate);
         Session.set(id+'-current', i);
+        var loop = Session.get(id+'-loop');
         i++;
-        if(i!==arr.length && iterate){
+        if(i!==arr.length && iterate || i===arr.length && loop){
+          i = loop && i===arr.length ? 0 : i;
           var playing = Meteor.setTimeout(function(){ play(i, currentData, true); }, 1000);
           $('#pause-button', buttonPlace).one('click', function(){
             Meteor.clearTimeout(playing);
@@ -262,7 +268,7 @@ Template.IMonChoroplethWidget.onRendered(function() {
             $('#play-button', buttonPlace).show();
           });
         }
-        else if(i===arr.length){
+        else if(i===arr.length && !loop){
           $('#pause-button', buttonPlace).hide(); 
           $('#play-button', buttonPlace).show(); 
           toggle('#step-forward-button', buttonPlace, true); 
@@ -301,12 +307,14 @@ Template.IMonChoroplethWidget.onRendered(function() {
     };
 
       $('#play-button', buttonPlace).show();
+      $('#loop-button', buttonPlace).show();
       $('#step-forward-button', buttonPlace).show();
       $('#step-backward-button', buttonPlace).show();
       if(arr.length>1){
         toggle('#play-button', buttonPlace, false);
         toggle('#step-backward-button', buttonPlace, false);
         toggle('#step-forward-button', buttonPlace, false);
+        toggle('#loop-button', buttonPlace, false);
         $('#play-button', buttonPlace).click(function(){
           $(this).hide();
           $('#pause-button', buttonPlace).show();
@@ -319,11 +327,17 @@ Template.IMonChoroplethWidget.onRendered(function() {
         $('#step-forward-button', buttonPlace).click(function(){
           moveCurrent(true, currData);
         });
+        $('#loop-button', buttonPlace).off();
+        $('#loop-button', buttonPlace).click(function(){
+          var enabled = Session.get(id+'-loop');
+          Session.set(id+'-loop', !enabled);
+        });
       }
       else{
         toggle('#play-button', buttonPlace, true);
         toggle('#step-backward-button', buttonPlace, true);
         toggle('#step-forward-button', buttonPlace, true);
+        toggle('#loop-button', buttonPlace, true);
       }
       play(0, currData, false);
     }

--- a/packages/imon-choropleth/client/widget.js
+++ b/packages/imon-choropleth/client/widget.js
@@ -100,7 +100,7 @@ Template.IMonChoroplethWidget.onRendered(function() {
           
           var colorScale;
           colorScale = d3.scale.quantile()
-            .domain(scores)
+            .domain([newIndicator.min, newIndicator.max])
             .range(range);
 
           var useQuantileScale = true;
@@ -197,7 +197,7 @@ Template.IMonChoroplethWidget.onRendered(function() {
                     return colorScale(country.value);
                   } else {
                     // No data for this country. Make it gray or something.
-                    return 'rgb(186,186,186)';
+                    return  'rgb(186,186,186)';
                   }
                 })
                 .style('transform', 'scaleY(' + Settings.map.squash + ')')

--- a/packages/imon-choropleth/client/widget.js
+++ b/packages/imon-choropleth/client/widget.js
@@ -4,17 +4,30 @@ Template.IMonChoroplethWidget.onCreated(function() {
     template.subscribe('imon_indicators');
     template.subscribe('imon_indicators_v2');
     template.subscribe('imon_countries_v2');
-    if(Template.currentData().indicatorName)
-      template.subscribe('imon_data_v2', 'all', Template.currentData().indicatorName, true);
+    if(Template.currentData().indicatorName){
+      template.subscribe('imon_data_v2', 'all', Template.currentData().indicatorName, !Template.currentData().animate);
+    }
   });
 });
 
-Template.IMonChoroplethWidget.onRendered(function() {
+Template.IMonChoroplethWidget.helpers({
+  year: function(){ 
+    var id = Template.instance().data.widget._id;
+    return Template.currentData().animate && Session.get(id+'-array') ? Session.get(id+'-array')[Session.get(id+'-current')] : '';
+  }
+});
 
+Template.IMonChoroplethWidget.onRendered(function() {
   var template = this;
+  var id = Template.instance().data.widget._id;
 
   template.autorun(function() {
+    template.$('.imon-choropleth-data').hide();
+    template.$('.animation-button').hide();
+    template.$('.animation-button').off();
     if (!template.subscriptionsReady()) {  return;  }
+    var svg;
+    var height = Template.currentData().animate ? Settings.map.height - 50 : Settings.map.height;
     // Make sure indicator is in the right format
     if(Template.currentData().indicatorId && !Template.currentData().indicatorName){ // because old structure used indicatorId
         var adName = IMonMethods.idToAdminName(Template.currentData().indicatorId);
@@ -37,29 +50,6 @@ Template.IMonChoroplethWidget.onRendered(function() {
       
     d3.select(template.find('.indicator_name')).text(newIndicator.shortName);
     
-    template.$('.imon-choropleth-data').html('');
-
-    var countryDataByCode = {};
-    var scores=[];
-    var scoreSet={};
-    var countries = IMonCountries.find().fetch(); // get list of all countries
-    for(var i=0; i<countries.length; i++){
-      var currCode = countries[i].code;
-      IMonRecent.find({ countryCode: currCode, indAdminName: Template.currentData().indicatorName }).forEach(function(d){
-        countryDataByCode[currCode.toUpperCase()] = d;
-        if(d.value !== undefined){
-          scores.push(d.value);
-        }
-        if(_.has(scoreSet, d.value)){
-          scoreSet[d.value]+=1;
-        }
-        else{
-          scoreSet[d.value]=1;
-        }
-      });
-    }
-
-
     var formatLegendLabelNumber = function formatLegendLabelNumber (number,precision){
       precision = precision ? precision : 1;
       if ( number > 1000000 ) {
@@ -77,131 +67,286 @@ Template.IMonChoroplethWidget.onRendered(function() {
       }
     };
 
-    var range        = ['#ece7f2','#bdd7e7','#6baed6','#3182bd','#08519c'];
-    
-    var uniqueScores = Object.keys(scoreSet);
-    uniqueScores = uniqueScores.sort(function(a, b){ return a-b; });
-    
-    if (uniqueScores.length === 4 ) {
-      range        = ['#ece7f2','#bdc9e1','#74a9cf','#0570b0'];
-    } else if ( uniqueScores.length === 3 ) {
-      range        = ['#ece7f2','#a6bddb','#2b8cbe'];
-    }
+    var currData = Template.currentData();
 
-    // by default, we use a quantile scale.
-    
-    var colorScale;
-    colorScale = d3.scale.quantile()
-      .domain(scores)
-      .range(range);
-
-    var useQuantileScale = true;
-
-    // but let's check, are quantile scales appropriate for this data?
-    if ( uniqueScores.length < 5 ) {
-      useQuantileScale = false;
-    } else {
-      _.each(colorScale.quantiles(), function(quantile,i){
-        if ( i > 0 && colorScale.quantiles()[i-1] === quantile){
-          console.log("Duplicate quantiles. Quantiles not working for this data. Use quantize.", colorScale.quantiles());
-          useQuantileScale = false;
-          return;
-        }
-      });
-    }
-
-    var lengendLabels;
-    
-    var setLegendLabels = function setLegendLabels(precision){
-      legendLabels = [];
-      if (useQuantileScale){
-        // quantile scale is best, most data-tailored scale when we have sufficient range of values.
-        legendLabels[0]= "< " + formatLegendLabelNumber(colorScale.quantiles()[0],precision);
-        _.each(colorScale.quantiles(), function(quantile,i){
-          legendLabels[i+1] = ">="+formatLegendLabelNumber(quantile,precision);
-        });
-      } else {
-        if ( uniqueScores.length <= 5 ) {
-          // use ordinal scale for just a few values.
-          colorScale = d3.scale.ordinal().domain(uniqueScores).range(range);
-          // sometimes these numbers are strings. why?
-          _.each(uniqueScores, function(score,i){
-            legendLabels[i] = formatLegendLabelNumber(Number(score),precision);
-          });
-        } else {
-          // use quantize scale to cut into 5 equal groups from min to max
-          var max = newIndicator.max;
-          // crude, temporary attempt to bring out resolution with lumpy data.
-          if (max > 100 && newIndicator.min < 10) {
-            max = 80;
+    Meteor.call('getChoroplethData', currData.indicatorName, !currData.animate, function(error, result){
+      var draw = function(isRecent, year, currentData, isFirst){
+      // 1. Common
+          var countryDataByCode = {};
+          var scores=[];
+          var scoreSet={};
+          var countries = isRecent ? result : result[index(result, year)].records; // get list of all countries
+          for(var i=0; i<countries.length; i++){
+            var d = countries[i];
+            var currCode = d.country;
+            countryDataByCode[currCode.toUpperCase()] = d;
+            scores.push(d.value);
+            scoreSet[d.value] = _.has(scoreSet, d.value) ? scoreSet[d.value] + 1 : 1;
           }
-          colorScale = d3.scale.quantize().domain([newIndicator.min,max]).range(range);
-          var buckets = _.map(range,function(color,i){ return newIndicator.min + ((i+1)*((max-newIndicator.min)/5)); });
-          legendLabels[0]= "< " + formatLegendLabelNumber(buckets[0],precision);
-          _.each(buckets, function(bucket,i){
-            legendLabels[i+1] = ">="+formatLegendLabelNumber(bucket,precision);
+          if(scores.length===0 && !isRecent) { return; }
+          var range        = ['#ece7f2','#bdd7e7','#6baed6','#3182bd','#08519c'];
+      
+          var uniqueScores = Object.keys(scoreSet);
+          uniqueScores = uniqueScores.sort(function(a, b){ return a-b; });
+          
+          if (uniqueScores.length === 4 ) {
+            range        = ['#ece7f2','#bdc9e1','#74a9cf','#0570b0'];
+          } else if ( uniqueScores.length === 3 ) {
+            range        = ['#ece7f2','#a6bddb','#2b8cbe'];
+          }
+
+          // by default, we use a quantile scale.
+          
+          var colorScale;
+          colorScale = d3.scale.quantile()
+            .domain(scores)
+            .range(range);
+
+          var useQuantileScale = true;
+
+          // but let's check, are quantile scales appropriate for this data?
+          if ( uniqueScores.length < 5 ) {
+            useQuantileScale = false;
+          } else {
+            _.each(colorScale.quantiles(), function(quantile,i){
+              if ( i > 0 && colorScale.quantiles()[i-1] === quantile){
+                console.log("Duplicate quantiles. Quantiles not working for this data. Use quantize.", colorScale.quantiles());
+                useQuantileScale = false;
+                return;
+              }
+            });
+          }
+
+          var lengendLabels;
+          
+          var setLegendLabels = function setLegendLabels(precision){
+            legendLabels = [];
+            if (useQuantileScale){
+              // quantile scale is best, most data-tailored scale when we have sufficient range of values.
+              legendLabels[0]= "< " + formatLegendLabelNumber(colorScale.quantiles()[0],precision);
+              _.each(colorScale.quantiles(), function(quantile,i){
+                legendLabels[i+1] = ">="+formatLegendLabelNumber(quantile,precision);
+              });
+            } else {
+              if ( uniqueScores.length <= 5 ) {
+                // use ordinal scale for just a few values.
+                colorScale = d3.scale.ordinal().domain(uniqueScores).range(range);
+                // sometimes these numbers are strings. why?
+                _.each(uniqueScores, function(score,i){
+                  legendLabels[i] = formatLegendLabelNumber(Number(score),precision);
+                });
+              } else {
+                // use quantize scale to cut into 5 equal groups from min to max
+                var max = newIndicator.max;
+                // crude, temporary attempt to bring out resolution with lumpy data.
+                if (max > 100 && newIndicator.min < 10) {
+                  max = 80;
+                }
+                colorScale = d3.scale.quantize().domain([newIndicator.min,max]).range(range);
+                var buckets = _.map(range,function(color,i){ return newIndicator.min + ((i+1)*((max-newIndicator.min)/5)); });
+                legendLabels[0]= "< " + formatLegendLabelNumber(buckets[0],precision);
+                _.each(buckets, function(bucket,i){
+                  legendLabels[i+1] = ">="+formatLegendLabelNumber(bucket,precision);
+                });
+            }
+          }
+        }
+
+        var precision =_.max(uniqueScores)>1 ? 1 : 2;
+        
+        setLegendLabels(precision);
+
+           var projection = d3.geo.winkel3()
+          .scale(Settings.map.scale)
+          .translate([
+            Settings.map.width / 2 - Settings.map.bumpLeft,
+            height / 2 + Settings.map.bumpDown
+          ])
+          ;
+
+        var legend = d3.legend.color()
+          .scale(colorScale)
+          .labelOffset(5)
+          .cells(5)
+            .labels(legendLabels);
+
+
+        // 2. Init function
+        var init = function(){
+          template.$('.imon-choropleth-data').empty();
+          template.$('.imon-choropleth-data').show();
+          svg = d3.select(template.find('.imon-choropleth')).append("svg:svg")
+            .attr("width", Settings.map.width)
+            .attr("height", height);
+
+
+          svg.append("g")
+            .attr("class", "legend")
+            .attr("transform", "translate(0, 100)");
+
+          CountryInfo.shapes(function(shapes) {
+            var feature = svg.selectAll("path")
+                .data(shapes.features)
+                .enter().append("svg:path")
+                .attr('class', 'country')
+                .style('fill', function(d) {
+                  var country = countryDataByCode[d.id];
+                  // We have country data. Make it pretty.
+                  if (country) {
+                    return colorScale(country.value);
+                  } else {
+                    // No data for this country. Make it gray or something.
+                    return 'rgb(186,186,186)';
+                  }
+                })
+                .style('transform', 'scaleY(' + Settings.map.squash + ')')
+                .attr("d", d3.geo.path().projection(projection));
+            feature.append("title")
+            .text(function(d) {
+                var title = d.properties.name;
+                var country = countryDataByCode[d.id];
+                if (country) {
+                  return title + ': ' + formatLegendLabelNumber(Number(country.value),precision) + '';
+                }
+                return title + ' (No data)';
+              });         
+          });
+      };
+
+      var update = function(){
+        var countryShapes = svg.selectAll('.country');
+        countryShapes.style('fill', function(d) {
+                  var country = countryDataByCode[d.id];
+                  // We have country data. Make it pretty.
+                  if (country) {
+                    return colorScale(country.value);
+                  } else {
+                    // No data for this country. Make it gray or something.
+                    return 'rgb(186,186,186)';
+                  }
+                }).select("title")
+              .text(function(d) {
+                var title = d.properties.name;
+                var country = countryDataByCode[d.id];
+                if (country) {
+                  return title + ': ' + formatLegendLabelNumber(Number(country.value),precision) + '';
+                }
+                return title + ' (No data)';
+        });
+      };
+      if(isRecent || isFirst){ init(); }
+      else{ update(); }
+      svg.select(".legend")
+        .call(legend);
+    };
+    if(currData.animate){
+      var buttonPlace = template.find('.choropleth-button');
+      var arr = getYears(result);
+      Session.set(id+'-array', arr);
+      Session.set(id+'-current', 0);
+      var play = function(i, currentData, iterate){
+        if(i!==0) toggle('#step-backward-button', buttonPlace, false);
+        else toggle('#step-backward-button', buttonPlace, true); 
+
+        if(i===arr.length-1) toggle('#step-forward-button', buttonPlace, true); 
+        else toggle('#step-forward-button', buttonPlace, false);
+
+        draw(false, arr[i], currentData, !iterate);
+        Session.set(id+'-current', i);
+        i++;
+        if(i!==arr.length && iterate){
+          var playing = Meteor.setTimeout(function(){ play(i, currentData, true); }, 1000);
+          $('#pause-button', buttonPlace).one('click', function(){
+            Meteor.clearTimeout(playing);
+            $(this).hide();
+            $('#play-button', buttonPlace).show();
           });
         }
+        else if(i===arr.length){
+          $('#pause-button', buttonPlace).hide(); 
+          $('#play-button', buttonPlace).show(); 
+          toggle('#step-forward-button', buttonPlace, true); 
+        }
+      };
+
+      var moveCurrent = function(isForward, currentData){
+      // 1. Get common years and current position;
+      var current = Session.get(id+'-current');
+
+      // 2. Calculate difference and new value 
+      var diff = isForward ? 1 : -1;
+      var newVal = current + diff;
+
+      // 3. Handle errors
+      if(newVal >= arr.length || newVal<0){ return; }
+
+      // 4. Move
+      var chosen = arr[newVal];
+      Session.set(id+'-current', newVal);
+      draw(false, chosen, currentData, false);
+
+      // 5. Toggle controllers
+      if(isForward){
+        toggle('#step-backward-button', buttonPlace, false); 
+        if(newVal===arr.length-1){
+          toggle('#step-forward-button', buttonPlace, true); 
+        } 
+      }
+      else{
+        toggle('#step-forward-button', buttonPlace, false); 
+        if(newVal===0){
+          toggle('#step-backward-button', buttonPlace, true); 
+        } 
       }
     };
 
-    var precision =_.max(uniqueScores)>1 ? 1 : 2;
-    
-    setLegendLabels(precision);
-      
-    var svg = d3.select(template.find('.imon-choropleth')).append("svg:svg")
-      .attr("width", Settings.map.width)
-      .attr("height", Settings.map.height);
-
-    var projection = d3.geo.winkel3()
-      .scale(Settings.map.scale)
-      .translate([
-        Settings.map.width / 2 - Settings.map.bumpLeft,
-        Settings.map.height / 2 + Settings.map.bumpDown
-      ])
-      ;
-
-    var legend = d3.legend.color()
-      .scale(colorScale)
-      .labelOffset(5)
-      .cells(5)
-        .labels(legendLabels);
-
-    svg.append("g")
-      .attr("class", "legend")
-      .attr("transform", "translate(0, 165)");
-
-    CountryInfo.shapes(function(shapes) {
-      var feature = svg.selectAll("path")
-          .data(shapes.features)
-          .enter().append("svg:path")
-          .attr('class', 'country')
-	  .style('fill', function(d) {
-            var country = countryDataByCode[d.id];
-            // We have country data. Make it pretty.
-            if (country) {
-              return colorScale(country.value);
-            } else {
-              // No data for this country. Make it gray or something.
-              return 'rgb(186,186,186)';
-            }
-          })
-          .style('transform', 'scaleY(' + Settings.map.squash + ')')
-          .attr("d", d3.geo.path().projection(projection));
-
-      feature.append("svg:title")
-        .text(function(d) {
-          var title = d.properties.name;
-          var country = countryDataByCode[d.id];
-          if (country) {
-            return title + ': ' + formatLegendLabelNumber(Number(country.value),precision) + '';
-          }
-          return title + ' (No data)';
+      $('#play-button', buttonPlace).show();
+      $('#step-forward-button', buttonPlace).show();
+      $('#step-backward-button', buttonPlace).show();
+      if(arr.length>1){
+        toggle('#play-button', buttonPlace, false);
+        toggle('#step-backward-button', buttonPlace, false);
+        toggle('#step-forward-button', buttonPlace, false);
+        $('#play-button', buttonPlace).click(function(){
+          $(this).hide();
+          $('#pause-button', buttonPlace).show();
+          var p = Session.get(id+'-current') === arr.length - 1 ? 0 :  Session.get(id+'-current');
+          play(p, currData, true);
         });
-
-      svg.select(".legend")
-        .call(legend);
-      
+        $('#step-backward-button', buttonPlace).click(function(){
+          moveCurrent(false, currData);
+        });
+        $('#step-forward-button', buttonPlace).click(function(){
+          moveCurrent(true, currData);
+        });
+      }
+      else{
+        toggle('#play-button', buttonPlace, true);
+        toggle('#step-backward-button', buttonPlace, true);
+        toggle('#step-forward-button', buttonPlace, true);
+      }
+      play(0, currData, false);
+    }
+    else{
+      draw(true, 0, currData);
+    }
     });
   });
 });
+
+function getYears(array){
+  var years = [];
+  array.forEach(function(record){ years.push(record.year); });
+  return years;
+}
+
+function toggle(selector, context, disable){
+  $(selector, context).prop('disabled', disable);
+}
+
+function index(arr, year){
+  for(var i=0; i<arr.length; i++){
+    if(arr[i].year === year) return i;
+  }
+  return -1;
+}

--- a/packages/imon-choropleth/imon-choropleth.js
+++ b/packages/imon-choropleth/imon-choropleth.js
@@ -1,6 +1,6 @@
 Settings = {
   defaultData: {
-    animate: false,
+    animate: true,
     indicatorName: 'hhnet'
   },
   suffix: {

--- a/packages/imon-choropleth/imon-choropleth.js
+++ b/packages/imon-choropleth/imon-choropleth.js
@@ -1,5 +1,6 @@
 Settings = {
   defaultData: {
+    animate: false,
     indicatorName: 'hhnet'
   },
   suffix: {
@@ -8,8 +9,8 @@ Settings = {
   },
   map: {
     width: 450,
-    height: 270,
-    scale: 110,
+    height: 250,
+    scale: 90,
     squash: 0.90,
     bumpDown: 30,
     bumpLeft: 30

--- a/packages/imon-choropleth/imon-choropleth.js
+++ b/packages/imon-choropleth/imon-choropleth.js
@@ -9,7 +9,7 @@ Settings = {
   },
   map: {
     width: 450,
-    height: 250,
+    height: 200,
     scale: 90,
     squash: 0.90,
     bumpDown: 30,

--- a/packages/imon-choropleth/package.js
+++ b/packages/imon-choropleth/package.js
@@ -12,6 +12,7 @@ Package.onUse(function(api) {
   api.use(['http'], 'server');
   api.use(['templating', 'epoch', 'd3js:d3'], 'client');
   api.addFiles('imon-choropleth.js');
+  api.addFiles(['server/methods.js'], 'server');
   api.addFiles([
     'client/lib/d3.geo.js',
     'client/info.html',

--- a/packages/imon-choropleth/server/methods.js
+++ b/packages/imon-choropleth/server/methods.js
@@ -1,0 +1,30 @@
+Meteor.methods({
+	getChoroplethData: function(indicatorName, recentOnly){
+		var IMon = recentOnly ? IMonRecent : IMonData;
+		var data = IMon.aggregate([
+		    { $match: { indAdminName: indicatorName } },
+		    { $sort: { countryCode: 1, date: -1 } },
+		    { $group: { _id: { countryCode: '$countryCode', date: { $year: '$date'} }, value: { $first: '$value' } } },
+		    { $group: { _id: '$_id.date', records: { $push: { country: '$_id.countryCode', value: '$value' } } } },
+		    { $project: { _id: 0, records: 1,  year: '$_id' } }
+		]).sort(function(a,b){ return a.year < b.year ? -1 : a.year > b.year ? 1 : 0; });
+		return recentOnly ? join(data) : data;
+	}
+});
+
+function join(arr){
+	var temp = [];
+	for(var i=arr.length - 1; i>=0; i--){
+		for(var j=0; j<arr[i].records.length; j++){
+			if(index(temp, arr[i].records[j].country)===-1){ temp.push(arr[i].records[j]); }
+		}
+	}
+	return temp;
+}
+
+function index(array, country){
+	for(var i=0; i<array.length; i++){
+		if(array[i].country === country){ return i; }
+	}
+	return -1;
+}

--- a/packages/imon-choropleth/server/methods.js
+++ b/packages/imon-choropleth/server/methods.js
@@ -1,30 +1,12 @@
 Meteor.methods({
-	getChoroplethData: function(indicatorName, recentOnly){
-		var IMon = recentOnly ? IMonRecent : IMonData;
-		var data = IMon.aggregate([
+	getChoroplethData: function(indicatorName){
+		var data = IMonData.aggregate([
 		    { $match: { indAdminName: indicatorName } },
 		    { $sort: { countryCode: 1, date: -1 } },
 		    { $group: { _id: { countryCode: '$countryCode', date: { $year: '$date'} }, value: { $first: '$value' } } },
 		    { $group: { _id: '$_id.date', records: { $push: { country: '$_id.countryCode', value: '$value' } } } },
 		    { $project: { _id: 0, records: 1,  year: '$_id' } }
 		]).sort(function(a,b){ return a.year < b.year ? -1 : a.year > b.year ? 1 : 0; });
-		return recentOnly ? join(data) : data;
+		return data;
 	}
 });
-
-function join(arr){
-	var temp = [];
-	for(var i=arr.length - 1; i>=0; i--){
-		for(var j=0; j<arr[i].records.length; j++){
-			if(index(temp, arr[i].records[j].country)===-1){ temp.push(arr[i].records[j]); }
-		}
-	}
-	return temp;
-}
-
-function index(array, country){
-	for(var i=0; i<array.length; i++){
-		if(array[i].country === country){ return i; }
-	}
-	return -1;
-}

--- a/packages/imon-data/server/publications.js
+++ b/packages/imon-data/server/publications.js
@@ -7,6 +7,8 @@ Meteor.publish('imon_data_v2', function(countries, indicators, recentOnly){
   RETURNS:
   - If requesting historical data: IMonData
   - If requesting recent data: IMonRecent
+  NOTE: IMonRecent holds the latest data provided for a country/indicator combination, NOT the data of the latest batch collected for that indicator.
+  Meaning, if there's an indicator X which had data for country Y in 2011 at the latest, while country Z's latest data for X was in 2014, IMonRecent has both an X/Y record and an X/Z record. 
   **/
   var selector = {};
   setSelector(selector, 'countryCode', countries);
@@ -14,7 +16,7 @@ Meteor.publish('imon_data_v2', function(countries, indicators, recentOnly){
   if(recentOnly){
     IMonData.aggregate([
       { $match: selector },
-      { $sort: { countryCode: 1, date: -1 } },
+      { $sort: { countryCode: 1, indAdminName: 1, date: -1 } },
       { $group: {_id: { countryCode: '$countryCode', indAdminName: '$indAdminName' }, date: { $first: '$date' }, value: { $first: '$value' } } },
       { $project: { _id: 0, countryCode: '$_id.countryCode', indAdminName: '$_id.indAdminName', date: 1, value: 1 } }
     ]).forEach(function(record){


### PR DESCRIPTION
Default behavior (and therefore backward-compatibility) should not be affected as the widget behaves as if animate is set to false if animate is not part of the widget's data. Works exactly like imon-bubblechart (except way cooler because the country visualizations are so much better than circles).
