### PR TITLE
Ability to select data from a certain year OR latest available data

### DIFF
--- a/packages/imon-barchart/client/settings.html
+++ b/packages/imon-barchart/client/settings.html
@@ -26,7 +26,7 @@
     <select class="year form-control" id="year-select-single" name="year-select-single">
     <option value="none" {{ isSelected byYear false }}>Latest available data</option>
     {{# each year }}
-    <option value="{{this}}" {{ isSelected this ../chosenYear }}>{{this}}</option>
+    <option value="{{this}}" {{ isSelected this chosenYear }}>{{this}}</option>
     {{/each}}
     </select>
   </div>

--- a/packages/imon-barchart/client/settings.html
+++ b/packages/imon-barchart/client/settings.html
@@ -22,6 +22,16 @@
   </div>
 
   <div class="form-group">
+    <label for="year-select-single">Year</label>
+    <select class="year form-control" id="year-select-single" name="year-select-single">
+    <option value="none" {{ isSelected byYear false }}>Latest available data</option>
+    {{# each year }}
+    <option value="{{this}}" {{ isSelected this ../chosenYear }}>{{this}}</option>
+    {{/each}}
+    </select>
+  </div>
+
+  <div class="form-group">
     <label>Countries <small class="countries-select-number"></small></label>
     <div class="countries-select-box">
       {{# each country }}

--- a/packages/imon-barchart/client/settings.html
+++ b/packages/imon-barchart/client/settings.html
@@ -26,7 +26,7 @@
     <select class="year form-control" id="year-select-single" name="year-select-single">
     <option value="none" {{ isSelected byYear false }}>Latest available data</option>
     {{# each year }}
-    <option value="{{this}}" {{ isSelected this chosenYear }}>{{this}}</option>
+    <option value="{{this}}" {{ isSelected this ../chosenYear }}>{{this}}</option>
     {{/each}}
     </select>
   </div>

--- a/packages/imon-barchart/client/settings.js
+++ b/packages/imon-barchart/client/settings.js
@@ -7,7 +7,8 @@ Template.IMonBarchartSettings.onCreated(function() {
 Template.IMonBarchartSettings.onRendered(function(){
   var template = this;
   var id = Template.instance().data.widget._id;
-  // Initially fill the years
+  // Logic here is only for single mode
+  // 1. Initially fill the years
   var indicator = Template.currentData().y.single.indicator;
   Meteor.call('getIndicatorYears', indicator, function(error, result){
     Session.set(id+'-years', result);

--- a/packages/imon-barchart/client/settings.js
+++ b/packages/imon-barchart/client/settings.js
@@ -83,9 +83,9 @@ Template.IMonBarchartSettings.events({
   'change #y-select-single': function(ev, template){
     var id = Template.instance().data.widget._id;
     var indicator = template.find('#y-select-single').value;
-    toggle('#year-select-single', template, true);
+    toggle(template.find('#year-select-single'), true);
     Meteor.call('getIndicatorYears', indicator, function(error, result){
-      toggle('#year-select-single', template, false);
+      toggle(template.find('#year-select-single'), false);
       Session.set(id+'-years', result);
     });
   },
@@ -107,6 +107,6 @@ function GetChecked(selector){
   return $(selector).map(function(){ return $(this).val(); }).get();
 }
 
-function toggle(selector, context, isDisabled){
-  $(selector, context).prop('disabled', isDisabled);
+function toggle(selector, isDisabled){
+  $(selector).prop('disabled', isDisabled);
 }

--- a/packages/imon-barchart/client/settings.js
+++ b/packages/imon-barchart/client/settings.js
@@ -1,6 +1,17 @@
 Template.IMonBarchartSettings.onCreated(function() {
-  this.subscribe('imon_indicators_v2');
-  this.subscribe('imon_countries_v2');
+  var template = this;
+  template.subscribe('imon_indicators_v2');
+  template.subscribe('imon_countries_v2');
+});
+
+Template.IMonBarchartSettings.onRendered(function(){
+  var template = this;
+  var id = Template.instance().data.widget._id;
+  // Initially fill the years
+  var indicator = Template.currentData().y.single.indicator;
+  Meteor.call('getIndicatorYears', indicator, function(error, result){
+    Session.set(id+'-years', result);
+  });
 });
 
 
@@ -8,11 +19,13 @@ Template.IMonBarchartSettings.helpers({
   singleIndicator: function() { return Template.currentData().mode === 'single' ? true : false; },
   indicator: function() { return IMonIndicators.find({}, { sort: { shortName: 1 }}); },
   country: function() { return IMonCountries.find({}, { sort: { name: 1 } } ); },
+  year: function(){ var id = Template.instance().data.widget._id; return Session.get(id+'-years'); },
   isSelected: function(a, b) { return a === b ? 'selected' : ''; },
   isChecked: function(a, b) { return a === b ? 'checked' : ''; },
   isInArray: function(val, arr) { return arr.indexOf(val) == -1 ? '' : 'checked'; }, 
   isSorted: function(){ return Template.currentData().sorted ? 'checked' : ''; }
 });
+
 
 Template.IMonBarchartSettings.events({
   'click .save-barchart-settings': function(ev, template) {
@@ -30,10 +43,17 @@ Template.IMonBarchartSettings.events({
     var yIndicatorSingle = mode === 'single' ? yIndicatorValue : Template.currentData().y.single.indicator;
     var yIndicatorMulti = mode === 'multi' ? yIndicatorValue : Template.currentData().y.multi.indicator;
 
+    //years
+    var year = template.find('#year-select-single').value;
+    var byYear = !(year === 'none');
+    var chosenYear = year === 'none' ? '' : parseInt(year);
+
     var newData = {
       title: template.find('.barchart-title').value,
       mode: mode,
       sorted: template.find('.sort-option').checked,
+      byYear: byYear,
+      chosenYear: chosenYear,
       x: {
         single:{
           indicator: xIndicatorSingle
@@ -60,6 +80,15 @@ Template.IMonBarchartSettings.events({
     $(template.find(div.show)).show();
     $(template.find(div.hide)).hide();
   },
+  'change #y-select-single': function(ev, template){
+    var id = Template.instance().data.widget._id;
+    var indicator = template.find('#y-select-single').value;
+    toggle('#year-select-single', template, true);
+    Meteor.call('getIndicatorYears', indicator, function(error, result){
+      toggle('#year-select-single', template, false);
+      Session.set(id+'-years', result);
+    });
+  },
   'change .countries-option': function(ev, template){ 
     var num_selected = GetChecked(template.findAll('.countries-option:checked')) == null ? 0 : GetChecked(template.findAll('.countries-option:checked')).length;
     $(template.find('.countries-select-number')).text(num_selected + ' SELECTED');
@@ -76,4 +105,8 @@ Template.IMonBarchartSettings.events({
 
 function GetChecked(selector){
   return $(selector).map(function(){ return $(this).val(); }).get();
+}
+
+function toggle(selector, context, isDisabled){
+  $(selector, context).prop('disabled', isDisabled);
 }

--- a/packages/imon-barchart/client/widget.html
+++ b/packages/imon-barchart/client/widget.html
@@ -1,5 +1,8 @@
 <template name="IMonBarchartWidget">
 <div class="barchart-error"></div>
   <h1>{{ title }}</h1>
+  {{#if byYear}}
+  	<h2>{{ chosenYear }}</h2>
+  {{/if}}
 <div class="barchart"></div>
 </template>

--- a/packages/imon-barchart/client/widget.js
+++ b/packages/imon-barchart/client/widget.js
@@ -13,9 +13,12 @@ Template.IMonBarchartWidget.onCreated(function() {
 
 Template.IMonBarchartWidget.onRendered(function() {
   var template = this;
-  var node = template.find('.barchart');
+  var redrawn = false;
+
   var widgetNode = template.firstNode.parentNode.parentNode;
   var $widgetBody = $(widgetNode).find('.widget-body');
+  var node = template.find('.barchart');
+
   var chart = d3.select(node).chart('Compose', function(options) {
     var xs = _.pluck(options.data, 'x'), ys = _.pluck(options.data, 'y');
 
@@ -38,7 +41,6 @@ Template.IMonBarchartWidget.onRendered(function() {
       }
     }];
 
-    var title = d3c.title('Custom Chart');
     var xAxis = d3c.axis('xAxis', {scale: scales.x, ticks: 3});
     var yAxis = d3c.axis('yAxis', {scale: scales.y, ticks: 3});
     var xAxisTitle = d3c.axisTitle(options.xAxisTitle);
@@ -65,19 +67,19 @@ Template.IMonBarchartWidget.onRendered(function() {
     chart.redraw();
   });
 
-  var redrawn = false;
   template.autorun(function() {
     if (!template.subscriptionsReady()) { return; }
-    var yIndicator;
-    var cachedIndicator = Template.currentData().indicator;
-    var xTitle;
-    var yTitle; 
+
+    var yIndicator, xTitle, yTitle;
+    var cachedIndicator = Template.currentData().indicator; 
 
     var data = [];
     var missing = []; // for the error
     var mode_reactive = Template.currentData().mode;
+
     if(mode_reactive === 'single'){ // Single indicator, multiple countries. Default.
-      // Make sure indicator is in right format
+
+      // 1. Make sure indicator is in right format
       if(!IMonMethods.isAdminName(Template.currentData().y.single.indicator)){
         var adName = IMonMethods.idToAdminName(Template.currentData().y.single.indicator);
         var newData = {
@@ -90,27 +92,33 @@ Template.IMonBarchartWidget.onRendered(function() {
         Template.currentData().set(newData);
       }
       
-      // Get the y-axis indicator ID
-      yIndicator = IMonIndicators.findOne({ adminName: Template.currentData().y.single.indicator });;
-      // Get the indicator as an object
+      // 2. Get the y-axis indicator ID
+      yIndicator = IMonIndicators.findOne({ adminName: Template.currentData().y.single.indicator });
+
+      // 3. Get the indicator as an object
       var dataIndicator = IMonIndicatorsD.findOne({ id: yIndicator.id });
-      if ( !cachedIndicator || cachedIndicator.id !== yIndicator.id){ // What this does is change the "From SOURCE" in the upper right corner of the widget
+
+      // 4. Change the source in the upper right corner
+      if ( !cachedIndicator || cachedIndicator.id !== yIndicator.id){  
         Template.currentData().set({indicator: dataIndicator});
       }
-      xTitle = 'Countries';
-      yTitle = yIndicator.shortName;
+
+      // 5. Chart Data
+      xTitle = 'Countries', yTitle = yIndicator.shortName;
+
       var IMon = Template.currentData().byYear ? IMonData : IMonRecent;
+
       IMonCountries.find({ code: {$in: Template.currentData().x.single.indicator } }).forEach(function(country){
         var selector = { countryCode: country.code, indAdminName: Template.currentData().y.single.indicator };
+
         if(Template.currentData().byYear){
           var chosenYear = Template.currentData().chosenYear;
-         selector.$where = function(){ return this.date.getFullYear() === chosenYear; };
+          selector.$where = function(){ return this.date.getFullYear() === chosenYear; };
        }
+
         var y = IMon.findOne(selector, { sort: { date: -1 } });
-        if (_.isUndefined(y)) {
-          missing.push(country.name); 
-          return; 
-        }
+        if (_.isUndefined(y)) { missing.push(country.name); return;  }
+
         var xValue = country.name, yValue = y.value;
 
         data.push({
@@ -122,14 +130,10 @@ Template.IMonBarchartWidget.onRendered(function() {
         });
       });
 
-      if(missing.length>0){ // If there is missing data
-        var message = '<strong><i class="fa fa-exclamation-triangle"></i></strong> No data found for ' + missing;
-        var error = template.find('.barchart-error');
-        $(error).html('<div class="alert alert-warning" id="barchart-error-message">'
-          +'<a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>'
-          + message
-          +'</div>');
-        $(template.find('#barchart-error-message')).on('closed.bs.alert', function () {
+      // 6. Handle errors
+      if(missing.length>0){ 
+        $(template.find('.barchart-error')).html(getErrorHTML(missing));
+        $(template.find('#barchart-error-message')).on('closed.bs.alert', function(){
           setChartDims();
           chart.redraw();
         });
@@ -138,24 +142,7 @@ Template.IMonBarchartWidget.onRendered(function() {
         $(template.find('#barchart-error-message')).remove(); // if there's an error present from a previous save
       }
     }
-    else{ // = If mode is 'multi'
-      if(cachedIndicator) // If we have a cached indicator, remove it. 
-        Template.currentData().set({indicator: undefined});
-      yIndicator = Template.currentData().y.multi.indicator;
-      yTitle = IMonCountries.findOne({ code: yIndicator }).name;
-      IMonRecent.find({ countryCode: yIndicator, indAdminName: { $in: Template.currentData().x.multi.indicator } }).forEach(function(field){
-        var yValue = Math.round(field.percent * 100).toFixed(2);
-        var xValue = IMonIndicators.findOne({ adminName: field.indAdminName }).shortName;
-
-        data.push({
-          x: xValue,
-          y: yValue,
-          code: field.id,
-          key: field.id,
-          label: yValue
-        });
-      });
-    }
+    // PLACE LOGIC FOR MODE = 'MULTI' HERE IN AN ELSE CLAUSE
 
     if(Template.currentData().sorted){ 
       data = _.sortBy(data, 'y'); 
@@ -177,6 +164,7 @@ Template.IMonBarchartWidget.onRendered(function() {
 
     var rotateAxisLabels = function(){
     // make x-axis labels diagonal
+    if(data.length===0){ return; }
     var xAxisText = template.findAll('[data-id="xAxis"] text');
     var label = d3.selectAll(xAxisText);
     var longest = _.max(data, function(row){ return row.x.length; }).x.length; // longest number of letters in x-labels
@@ -196,3 +184,10 @@ Template.IMonBarchartWidget.onRendered(function() {
 
   });
 });
+
+function getErrorHTML(missingCountries){
+  return '<div class="alert alert-warning" id="barchart-error-message">'
+          +'<a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>'
+          +'<strong><i class="fa fa-exclamation-triangle"></i></strong> No data found for ' + missingCountries
+          +'</div>';
+}

--- a/packages/imon-barchart/client/widget.js
+++ b/packages/imon-barchart/client/widget.js
@@ -4,7 +4,7 @@ Template.IMonBarchartWidget.onCreated(function() {
     var mode = Template.currentData().mode;
     var indicators = mode === 'single' ? Template.currentData().y.single.indicator :  Template.currentData().x.multi.indicator;
     var countries = mode === 'single' ? Template.currentData().x.single.indicator : Template.currentData().y.multi.indicator;
-    template.subscribe('imon_data_v2', countries, indicators, true);
+    template.subscribe('imon_data_v2', countries, indicators, !Template.currentData().byYear);
     template.subscribe('imon_indicators'); // for provider data
     template.subscribe('imon_indicators_v2');
     template.subscribe('imon_countries_v2');
@@ -99,8 +99,14 @@ Template.IMonBarchartWidget.onRendered(function() {
       }
       xTitle = 'Countries';
       yTitle = yIndicator.shortName;
+      var IMon = Template.currentData().byYear ? IMonData : IMonRecent;
       IMonCountries.find({ code: {$in: Template.currentData().x.single.indicator } }).forEach(function(country){
-        var y = IMonRecent.findOne({ countryCode: country.code, indAdminName: Template.currentData().y.single.indicator });
+        var selector = { countryCode: country.code, indAdminName: Template.currentData().y.single.indicator };
+        if(Template.currentData().byYear){
+          var chosenYear = Template.currentData().chosenYear;
+         selector.$where = function(){ return this.date.getFullYear() === chosenYear; };
+       }
+        var y = IMon.findOne(selector, { sort: { date: -1 } });
         if (_.isUndefined(y)) {
           missing.push(country.name); 
           return; 

--- a/packages/imon-barchart/imon_barchart.js
+++ b/packages/imon-barchart/imon_barchart.js
@@ -11,6 +11,8 @@ Settings = {
   defaultData: {
     title: 'Bar Chart',
     mode: 'single', // other mode: 'multi', refers to the number of indicators.
+    byYear: false,
+    chosenYear: '',
     sorted: false, // sort by value. When false, the x-axis is sorted by name instead.
     x: {
       single: {

--- a/packages/imon-barchart/imon_barchart.js
+++ b/packages/imon-barchart/imon_barchart.js
@@ -2,11 +2,6 @@ Settings = {
   chart: {
     padding: { right: 40, bottom: 80 },
     margins: { top: 30, bottom: 0, right: 35 },
-    dots: {
-      size: 5,
-      color: '#378E00',
-      opacity: 0.7
-    }
   },
   defaultData: {
     title: 'Bar Chart',
@@ -19,7 +14,7 @@ Settings = {
         indicator: ["isr", "ita", "mex", "mar", "kor", "gbr", "usa"]
       },
       multi: {
-        indicator: ['downloadkbps', 'ipr'] // Average download speed, % of people using the internet. temp.
+        indicator: ['downloadkbps', 'speedkbps'] // Average download speed, % of people using the internet. temp.
       }
     },
     y: {

--- a/packages/imon-data/package.js
+++ b/packages/imon-data/package.js
@@ -14,7 +14,7 @@ Package.onUse(function(api) {
 
   api.addFiles(['imon-data.js']);
   api.addFiles(['client.js'], 'client');
-  api.addFiles(['server/seed.js', 'server/publications.js'], 'server');
+  api.addFiles(['server/seed.js', 'server/publications.js', 'server/methods.js'], 'server');
 
   api.export('IMonIndicators');
   api.export('IMonCountries');

--- a/packages/imon-data/server/methods.js
+++ b/packages/imon-data/server/methods.js
@@ -1,0 +1,11 @@
+Meteor.methods({
+	'getIndicatorYears': function(indicatorName){
+		var records = IMonData.aggregate([
+			{ $match: { indAdminName: indicatorName } },
+			{ $sort: { date: 1 } },
+			{ $group: { _id: 'indAdminName', years: { $push: { $year: '$date' } } } },
+			{ $project: { _id: 0, years: 1 } }
+		]);
+		return _.uniq(records[0].years);
+	}
+});

--- a/packages/imon-data/server/methods.js
+++ b/packages/imon-data/server/methods.js
@@ -1,11 +1,27 @@
 Meteor.methods({
 	'getIndicatorYears': function(indicatorName){
+		var selector = {};
+		selector.indAdminName = _.isArray(indicatorName) ? { $in: indicatorName } : indicatorName;
 		var records = IMonData.aggregate([
-			{ $match: { indAdminName: indicatorName } },
+			{ $match: selector },
 			{ $sort: { date: 1 } },
-			{ $group: { _id: 'indAdminName', years: { $push: { $year: '$date' } } } },
+			{ $group: { _id: '$indAdminName', years: { $push: { $year: '$date' } } } },
 			{ $project: { _id: 0, years: 1 } }
 		]);
-		return _.uniq(records[0].years);
+		records.sort(function(a, b){ return a.years.length < b.years.length ? -1 : a.years.length > b.years.length ? 1 : 0; });
+		return intersection(records);
 	}
 });
+
+function intersection(records){
+  var years = records[0].years; // shortest array
+  var result = [];
+  var count;
+  for(var i=0; i<years.length; i++){
+    count = 1;
+    for(var j=1; j<records.length; j++)
+      if(records[j].years.indexOf(years[i]) !== -1) { count++; }
+    if(count === records.length && result.indexOf(years[i]) === -1) { result.push(years[i]); } 
+  }
+  return result.sort(function(a,b){ return a-b; });
+}

--- a/packages/imon-percent/client/settings.html
+++ b/packages/imon-percent/client/settings.html
@@ -25,7 +25,7 @@
     <option value="{{this}}" {{ isSelected this ../chosenYear }}>{{this}}</option>
     {{/each}}
     </select>
-  </div>
+</div>
 <div class="form-group">
   <label for="color-select">Unit color</label>
   <select class="form-control color-select" id="color-select">

--- a/packages/imon-percent/client/settings.html
+++ b/packages/imon-percent/client/settings.html
@@ -18,6 +18,15 @@
   </select>
 </div>
 <div class="form-group">
+    <label for="year-select-single">Year</label>
+    <select class="year form-control" id="year-select-single" name="year-select-single">
+    <option value="none" {{ isSelected byYear false }}>Latest available data</option>
+    {{# each year }}
+    <option value="{{this}}" {{ isSelected this ../chosenYear }}>{{this}}</option>
+    {{/each}}
+    </select>
+  </div>
+<div class="form-group">
   <label for="color-select">Unit color</label>
   <select class="form-control color-select" id="color-select">
     {{# each colors }}

--- a/packages/imon-percent/client/settings.js
+++ b/packages/imon-percent/client/settings.js
@@ -3,9 +3,21 @@ Template.IMonPercentSettings.onCreated(function() {
   this.subscribe('imon_indicators_v2');
 });
 
+Template.IMonPercentSettings.onRendered(function(){
+  var template = this;
+  var id = Template.instance().data.widget._id;
+  // Logic here is only for single mode
+  // 1. Initially fill the years
+  var indicator = Template.currentData().indicatorName;
+  Meteor.call('getIndicatorYears', indicator, function(error, result){
+    Session.set(id+'-years', result);
+  });
+});
+
 
 Template.IMonPercentSettings.helpers({
   countries: function() { return IMonCountries.find({}, { sort: { name: 1 } }); },
+  year: function(){ var id = Template.instance().data.widget._id; return Session.get(id+'-years'); },
   indicators: function() { return IMonIndicators.find({ displayClass: 'percentage', max: { $lte: 100 } }, { sort: { shortName: 1 } }); },
   isSelected: function(a, b) { return a === b ? 'selected' : ''; },
   isChecked: function(a, b) { return a === b ? 'checked' : ''; },
@@ -25,12 +37,17 @@ Template.IMonPercentSettings.events({
   'click .save-settings': function(ev, template) {
     var country = template.find('.country-select').value;
     var ind = template.find('.indicator-select').value;
+    var year = template.find('#year-select-single').value;
+    var byYear = !(year === 'none');
+    var chosenYear = year === 'none' ? '' : parseInt(year);
     var available = IMonCountries.findOne({ code: country }).dataSources.indexOf(ind) === -1 ? false : true;
     if(available){
       $('#percent-error-message').remove();
       var newData = {
       country: country,
       indicatorName: ind,
+      byYear: byYear,
+      chosenYear: chosenYear,
       color: template.find('.color-select').value
       };
       template.closeSettings();
@@ -46,9 +63,20 @@ Template.IMonPercentSettings.events({
         + message
         +'</div>');
      }
+  },
+  'change .indicator-select':function(ev, template){
+    var id = Template.instance().data.widget._id;
+    var indicator = template.find('.indicator-select').value;
+    toggle(template.find('#year-select-single'), true);
+    Meteor.call('getIndicatorYears', indicator, function(error, result){
+      toggle(template.find('#year-select-single'), false);
+      Session.set(id+'-years', result);
+    });
   }
 });
 
-
+function toggle(selector, isDisabled){
+  $(selector).prop('disabled', isDisabled);
+}
 
 

--- a/packages/imon-percent/client/widget.css
+++ b/packages/imon-percent/client/widget.css
@@ -2,6 +2,10 @@
   font-size: 1em;
 }
 
+.imon-percent h3{
+  float: right;
+}
+
 .imon-percent .fa.colored {
   color: #6192BD;
 }

--- a/packages/imon-percent/client/widget.html
+++ b/packages/imon-percent/client/widget.html
@@ -1,7 +1,7 @@
 <template name="IMonPercentWidget">
 <div class="percent-title">
   <h1></h1>
-  <h2></h2>
+  <h2></h2>{{#if byYear}}<h3>{{ chosenYear }}</h3>{{/if}}
 </div>
 <div class="row nodeRow">
   <div class="col-xs-8">

--- a/packages/imon-percent/client/widget.js
+++ b/packages/imon-percent/client/widget.js
@@ -5,7 +5,7 @@ Template.IMonPercentWidget.onCreated(function() {
     template.subscribe('imon_indicators_v2');
     template.subscribe('imon_countries_v2');
     if(Template.currentData().indicatorName){
-      template.subscribe('imon_data_v2', Template.currentData().country, Template.currentData().indicatorName, true);
+      template.subscribe('imon_data_v2', Template.currentData().country, Template.currentData().indicatorName, !Template.currentData().byYear);
     }
   });
 });
@@ -39,7 +39,12 @@ Template.IMonPercentWidget.onRendered(function(){
     var container = template.find('.users-container');
     var title = template.find('.percent-title');
     var valuePlace = template.find('.indicator-value');
-    var indicatorValue = IMonRecent.findOne({ indAdminName: Template.currentData().indicatorName, countryCode: Template.currentData().country }).value;
+    var IMon = Template.currentData().byYear ? IMonData : IMonRecent;
+    var selector = { indAdminName: Template.currentData().indicatorName, countryCode: Template.currentData().country }; 
+    if(Template.currentData().byYear){ selector.$where = function(){ return this.date.getFullYear() === Template.currentData().chosenYear; }; }
+    var record = IMon.findOne(selector, { $sort: { date: -1 } });
+    if(_.isUndefined(record)){ return; }
+    var indicatorValue = record.value;
     var countryName = IMonCountries.findOne({ code: Template.currentData().country }).name;
     var indicatorName = IMonIndicators.findOne({ adminName: currName }).shortName;
     var color = Template.currentData().color;

--- a/packages/imon-percent/imon_percent.js
+++ b/packages/imon-percent/imon_percent.js
@@ -6,6 +6,8 @@ Settings = {
   },
   defaultData: {
     country: 'usa',
+    byYear: false,
+    chosenYear: '',
     indicatorName: 'bbrate',
     color: '#6192BD'
   }

--- a/packages/imon-scatter/client/settings.html
+++ b/packages/imon-scatter/client/settings.html
@@ -57,6 +57,13 @@
 </div>
 
 <div class="form-group">
+    <label for="year-select-single">Year</label>
+    <select class="year form-control" id="year-select-single" name="year-select-single">
+    <option value="none" {{ isSelected byYear false }}>Latest available data</option>
+    {{# each year }}
+    <option value="{{this}}" {{ isSelected this ../chosenYear }}>{{this}}</option>
+    {{/each}}
+    </select>
 </div>
 
 <button class="btn btn-primary save-settings">Save</button>

--- a/packages/imon-scatter/client/settings.js
+++ b/packages/imon-scatter/client/settings.js
@@ -2,16 +2,33 @@ Template.IMonScatterSettings.onCreated(function() {
   this.subscribe('imon_indicators_v2');
 });
 
+Template.IMonScatterSettings.onRendered(function(){
+  var template = this;
+  var id = Template.instance().data.widget._id;
+  // Logic here is only for single mode
+  // 1. Initially fill the years
+  var indicators = [Template.currentData().x.indicator, Template.currentData().y.indicator];
+  Meteor.call('getIndicatorYears', indicators, function(error, result){
+    Session.set(id+'-years', result);
+  });
+});
+
 Template.IMonScatterSettings.helpers({
   indicators: function() { return IMonIndicators.find({}, { sort: { shortName: 1 }}); },
   isSelected: function(a, b) { return a === b ? 'selected' : ''; },
   isChecked: function(val) { return val ? 'checked' : ''; },
+  year: function(){ var id = Template.instance().data.widget._id; return Session.get(id+'-years'); }
 });
 
 Template.IMonScatterSettings.events({
   'click .save-settings': function(ev, template) {
+    var year = template.find('#year-select-single').value;
+    var byYear = !(year === 'none');
+    var chosenYear = year === 'none' ? '' : parseInt(year);
     var newData = {
       title: template.find('#chart-title').value,
+      byYear: byYear,
+      chosenYear: chosenYear,
       x: {
         indicator: template.find('#x-select').value,
         log: template.find('#x-log').checked,
@@ -24,5 +41,18 @@ Template.IMonScatterSettings.events({
       }};
     template.closeSettings();
     this.set(newData);
+  },
+  'change #x-select, change #y-select':function(ev, template){
+    var id = Template.instance().data.widget._id;
+    var indicators = [template.find('#x-select').value, template.find('#y-select').value];
+    toggle(template.find('#year-select-single'), true);
+    Meteor.call('getIndicatorYears', indicators, function(error, result){
+      toggle(template.find('#year-select-single'), false);
+      Session.set(id+'-years', result);
+    });
   }
 });
+
+function toggle(selector, isDisabled){
+  $(selector).prop('disabled', isDisabled);
+}

--- a/packages/imon-scatter/client/widget.css
+++ b/packages/imon-scatter/client/widget.css
@@ -2,6 +2,9 @@
   border: 0;
 }
 
+.imon-scatter h2{
+	margin:0;
+}
 .imon-scatter .chart-labels .chart-label {
   pointer-events: none;
   visibility: hidden;

--- a/packages/imon-scatter/client/widget.html
+++ b/packages/imon-scatter/client/widget.html
@@ -1,5 +1,6 @@
 <template name="IMonScatterWidget">
   <h1>{{ title }}</h1>
+  {{#if byYear}}<h2>{{chosenYear}}</h2>{{/if}}
   {{# unless Template.subscriptionsReady }}
   	{{widgetLoading}}
   {{/unless}}

--- a/packages/imon-scatter/client/widget.js
+++ b/packages/imon-scatter/client/widget.js
@@ -5,7 +5,7 @@ Template.IMonScatterWidget.onCreated(function() {
       Template.currentData().x.indicator,
       Template.currentData().y.indicator
     ];
-    template.subscribe('imon_data_v2', 'all', indicators, true);
+    template.subscribe('imon_data_v2', 'all', indicators, !Template.currentData().byYear);
     template.subscribe('imon_indicators_v2');
     template.subscribe('imon_countries_v2');
   });
@@ -94,8 +94,12 @@ Template.IMonScatterWidget.onRendered(function() {
 
     var data = [];
     IMonCountries.find().forEach(function(country) {
-      var x = IMonRecent.findOne({ countryCode: country.code, indAdminName: xIndicator });
-      var y = IMonRecent.findOne({ countryCode: country.code, indAdminName: yIndicator });
+      var IMon = Template.currentData().byYear ? IMonData : IMonRecent;
+      var xSelector = ySelector = { countryCode: country.code };
+      xSelector.indAdminName = xIndicator, ySelector.indAdminName = yIndicator;
+      if(Template.currentData().byYear){ xSelector.$where = ySelector.$where = function(){ return this.date.getFullYear()===Template.currentData().chosenYear; }; }
+      var x = IMon.findOne(xSelector, { $sort: { date: -1 } });
+      var y = IMon.findOne(ySelector, { $sort: { date: -1 } });
       if (_.isUndefined(x) || _.isUndefined(y)) { return; }
 
       var xValue = x.value, yValue = y.value;

--- a/packages/imon-scatter/imon_scatter.js
+++ b/packages/imon-scatter/imon_scatter.js
@@ -1,6 +1,6 @@
 Settings = {
   chart: {
-    padding: { right: 40, bottom: 80 },
+    padding: { right: 40, bottom: 100 },
     margins: { top: 30, bottom: 0, right: 35 },
     dots: {
       size: 5,
@@ -10,6 +10,8 @@ Settings = {
   },
   defaultData: {
     title: 'Scatter Plot',
+    byYear: false,
+    chosenYear: '',
     x: {
       indicator: 'ipr', // Percentage of individuals using the Internet
       log: false,

--- a/packages/imon-speedometer/client/settings.html
+++ b/packages/imon-speedometer/client/settings.html
@@ -18,6 +18,15 @@
   </select>
 </div>
 <div class="form-group">
+    <label for="year-select-single">Year</label>
+    <select class="year form-control" id="year-select-single" name="year-select-single">
+    <option value="none" {{ isSelected byYear false }}>Latest available data</option>
+    {{# each year }}
+    <option value="{{this}}" {{ isSelected this ../chosenYear }}>{{this}}</option>
+    {{/each}}
+    </select>
+</div>
+<div class="form-group">
   <label for="color-select">Color</label>
   <select class="color form-control" id="color-select" name="color">
     {{# each colors }}

--- a/packages/imon-speedometer/client/widget.css
+++ b/packages/imon-speedometer/client/widget.css
@@ -2,6 +2,17 @@
   margin-top: 15%;
 }
 
+.imon-speedometer .title h2{
+	margin:0;
+	display:inline;
+}
+
+.imon-speedometer .title h3{
+	float:right;
+	display: inline;
+	margin:0;
+}
+
 .imon-speedometer .title h1{
 	text-transform: capitalize;
 }

--- a/packages/imon-speedometer/client/widget.html
+++ b/packages/imon-speedometer/client/widget.html
@@ -2,6 +2,7 @@
 <div class="title">
 	<h1></h1>
 	<h2></h2>
+	{{#if byYear}}<h3>{{chosenYear}}</h3>{{/if}}
 </div>
 <div class="gauge"></div>
 </template>

--- a/packages/imon-speedometer/client/widget.js
+++ b/packages/imon-speedometer/client/widget.js
@@ -5,7 +5,7 @@ Template.IMonSpeedometerWidget.onCreated(function() {
     template.subscribe('imon_indicators_v2');
     template.subscribe('imon_countries_v2');
     if(Template.currentData().indicatorName){
-      template.subscribe('imon_data_v2', Template.currentData().country, Template.currentData().indicatorName, true);
+      template.subscribe('imon_data_v2', Template.currentData().country, Template.currentData().indicatorName, !Template.currentData().byYear);
     }
   });
 });
@@ -74,10 +74,10 @@ Template.IMonSpeedometerWidget.onRendered(function() {
     $('h1', titlePlace).text(indicatorName);
     $('h2', titlePlace).text(countryName);
 
-    var indicator = IMonRecent.findOne({ 
-      countryCode: Template.currentData().country,
-      indAdminName: Template.currentData().indicatorName
-    });
+    var IMon = Template.currentData().byYear ? IMonData : IMonRecent;
+    var selector = { countryCode: Template.currentData().country, indAdminName: Template.currentData().indicatorName };
+    if(Template.currentData().byYear){ selector.$where = function(){ return this.date.getFullYear() === Template.currentData().chosenYear; }; }
+    var indicator = IMon.findOne(selector, { $sort: { date: -1 } });
     var speedPercent = 0.001;
     if (indicator && getPercent(indicator.value, currInd.max) > 0) {
       speedPercent = getPercent(indicator.value, currInd.max) * 100;

--- a/packages/imon-speedometer/imon_speedometer.js
+++ b/packages/imon-speedometer/imon_speedometer.js
@@ -2,6 +2,8 @@ Settings = {
   gaugeWidth: 146, // per unit width
   defaultData: {
     country: 'usa',
+    byYear: false,
+    chosenYear: '',
     indicatorName: 'speedkbps', // Average connection speed (kbps)
     color: '#6192BD'
  }


### PR DESCRIPTION
As discussed on Friday, the `IMonRecent` displays, by default, the latest available data for the country/indicator combination regardless of whether or not it's the last batch of data for that indicator as a whole.

To clear that up, and to make use of historical data in widgets that don't have trends/timelines or animation, the user can now select the year for which they want to display the data (or opt for 'Latest available data') in the following widgets:
- `imon-barchart`
- `imon-scatter`
- `imon-percent`
- `imon-speedometer`

The years displayed in the options are only those available for the selected indicator(s) in the settings at the time. If a specific year is chosen, the displayed year is visible on the widget.
