### PR TITLE
Small fixes (#13669 & #13671)

### DIFF
--- a/packages/broadband-cost/broadband_cost.js
+++ b/packages/broadband-cost/broadband_cost.js
@@ -10,12 +10,16 @@ Settings = {
   speedRegex: /(\d+-)?\d+ Mbps/,
   maxSpeed: '25 Mbps',
   lowerCellClassBounds: { 66: 'danger', 33: 'warning', 0: 'success' },
-  defaultCountry: { country: { name: 'United States', code: 'usa' } }
+  defaultData: {
+   country: { name: 'United States', code: 'usa' },
+   byYear: false,
+   chosenYear: ''
+ }
 };
 
 BroadbandCostWidget = function(doc) {
   Widget.call(this, doc);
-  _.defaults(this.data, Settings.defaultCountry);
+  _.defaults(this.data, Settings.defaultData);
 };
 
 BroadbandCostWidget.prototype = Object.create(Widget.prototype);

--- a/packages/broadband-cost/client/settings.html
+++ b/packages/broadband-cost/client/settings.html
@@ -4,17 +4,22 @@
   <label for="country-select">Country</label>
   <select class="country form-control" id="country-select" name="country">
         {{# each countries }}
-        {{> BroadbandOption }}
+  		<option value="{{ code }}" {{ isSelected code ../country.code }}>{{ name }}</option>
         {{/each}}
   </select>
 </div>
-
+<div class="form-group">
+  <label for="year-select">Year</label>
+  <select class="year form-control" id="year-select" name="year">
+  		<option value="none" {{ isSelected byYear false }}>Latest available data</option>
+        {{# each year }}
+		<option value="{{ this }}" {{ isSelected this ../chosenYear }}>{{ this }}</option>
+        {{/each}}
+  </select>
+</div>
 <button class="btn btn-primary save-settings">Save</button>
 {{ else }}
   {{ widgetLoading }}
 {{/if}}
 </template>
 
-<template name="BroadbandOption">
-  <option value="{{ code }}" {{ isSelected code ../country.code }}>{{ name }}</option>
-</template>

--- a/packages/broadband-cost/client/settings.js
+++ b/packages/broadband-cost/client/settings.js
@@ -2,25 +2,40 @@ Template.BroadbandCostSettings.onCreated(function() {
   this.subscribe('imon_countries_v2');
 });
 
+Template.BroadbandCostSettings.onRendered(function(){
+  var template = this;
+  var id = Template.instance().data.widget._id;
+  // Logic here is only for single mode
+  // 1. Initially fill the years
+  var indicator = Settings.indicatorIds;
+  Meteor.call('getIndicatorYears', indicator, function(error, result){
+    Session.set(id+'-years', result);
+  });
+});
+
 Template.BroadbandCostSettings.helpers({
-  countries: function() { return IMonCountries.find({}, { sort: { name: 1 } });}
+  countries: function() { return IMonCountries.find({}, { sort: { name: 1 } });},
+  year: function(){ var id = Template.instance().data.widget._id; return Session.get(id+'-years'); },
+  isSelected: function(a, b) { return a === b ? 'selected' : ''; }
 });
 
 Template.BroadbandCostSettings.events({
   'click .save-settings': function(ev, template) {
     var countryCode = template.find('.country').value;
+    var year = template.find('.year').value;
+    var byYear = !(year === 'none');
+    var chosenYear = year === 'none' ? '' : parseInt(year);
+
     var newData = {
       country: {
         name: IMonCountries.findOne({ code: countryCode }).name,
         code: countryCode
-      }
+      },
+      byYear: byYear,
+      chosenYear: chosenYear
     };
     this.set(newData);
     template.closeSettings();
   }
-});
-
-Template.BroadbandOption.helpers({
-  isSelected: function(a, b) { return a === b ? 'selected' : ''; },
 });
 

--- a/packages/broadband-cost/client/widget.css.less
+++ b/packages/broadband-cost/client/widget.css.less
@@ -9,4 +9,10 @@
       }
     }
   }
+  h2,h3{
+    display:inline;
+  }
+  h3{
+    float:right;
+  }
 }

--- a/packages/broadband-cost/client/widget.html
+++ b/packages/broadband-cost/client/widget.html
@@ -1,13 +1,14 @@
 <template name="BroadbandCostWidget">
 <h1>Broadband Cost</h1>
 <h2>{{ country.name }}</h2>
+{{# if byYear}}<h3>{{chosenYear}}</h3>{{/if}}
 {{# if Template.subscriptionsReady }}
 <table class="cost-indicators table table-condensed">
   <tbody>
     <tr>
     {{# each indicators }}
-    <td class="{{ cellColor ../country.code }}">
-      {{# if dataValue ../country.code }}{{ percentValue ../country.code }}{{ else }}&ndash;{{/if}}
+    <td class="{{ cellColor ../country.code ../byYear ../chosenYear }}">
+      {{# if dataValue ../country.code ../byYear ../chosenYear }}{{ percentValue ../country.code ../byYear ../chosenYear }}{{ else }}&ndash;{{/if}}
     </td>
     {{/each}}
     </tr>

--- a/packages/connection-speed/client/settings.html
+++ b/packages/connection-speed/client/settings.html
@@ -4,7 +4,17 @@
   <label for="country-select">Country</label>
   <select class="country form-control" id="country-select" name="country">
         {{# each countries }}
-        {{> ConnectionSpeedOption }}
+	  	<option value="{{ code }}" {{ isSelected code ../country.code }}>{{ name }}</option>
+        {{/each}}
+  </select>
+</div>
+
+<div class="form-group">
+  <label for="year-select">Year</label>
+  <select class="year form-control" id="year-select" name="year">
+  		<option value="none" {{ isSelected byYear false }}>Latest available data</option>
+        {{# each year }}
+	  	<option value="{{ this }}" {{ isSelected this ../chosenYear }}>{{ this }}</option>
         {{/each}}
   </select>
 </div>
@@ -13,8 +23,4 @@
 {{ else }}
   {{ widgetLoading }}
 {{/if}}
-</template>
-
-<template name="ConnectionSpeedOption">
-  <option value="{{ code }}" {{ isSelected code ../country.code }}>{{ name }}</option>
 </template>

--- a/packages/connection-speed/client/settings.js
+++ b/packages/connection-speed/client/settings.js
@@ -2,21 +2,36 @@ Template.ConnectionSpeedSettings.onCreated(function() {
   this.subscribe('imon_countries_v2');
 });
 
+Template.ConnectionSpeedSettings.onRendered(function(){
+  var template = this;
+  var id = Template.instance().data.widget._id;
+  // Logic here is only for single mode
+  // 1. Initially fill the years
+  var indicator = Settings.indicatorId;
+  Meteor.call('getIndicatorYears', indicator, function(error, result){
+    Session.set(id+'-years', result);
+  });
+});
+
 Template.ConnectionSpeedSettings.helpers({
+  isSelected: function(a, b) { return a === b ? 'selected' : ''; },
+  year: function(){ var id = Template.instance().data.widget._id; return Session.get(id+'-years'); },
   countries: function() { return IMonCountries.find({ dataSources: Settings.indicatorId }, { sort: { name: 1 } }); }
 });
 
 Template.ConnectionSpeedSettings.events({
   'click .save-settings': function(ev, template) {
     var countryCode = template.find('.country').value;
+    var year = template.find('.year').value;
+    var byYear = !(year === 'none');
+    var chosenYear = year === 'none' ? '' : parseInt(year);
+
     var newData = {
-      country: IMonCountries.findOne({ code: countryCode })
+      country: IMonCountries.findOne({ code: countryCode }),
+      byYear: byYear,
+      chosenYear: chosenYear
     };
     template.closeSettings();
     this.set(newData);
   }
-});
-
-Template.ConnectionSpeedOption.helpers({
-  isSelected: function(a, b) { return a === b ? 'selected' : ''; },
 });

--- a/packages/connection-speed/client/widget.css
+++ b/packages/connection-speed/client/widget.css
@@ -1,3 +1,11 @@
 .connection-speed .gauge {
   margin-top: 15%;
 }
+
+.connection-speed h2, .connection-speed h3{
+	display: inline;
+}
+
+.connection-speed h3{
+	float:right;
+}

--- a/packages/connection-speed/client/widget.html
+++ b/packages/connection-speed/client/widget.html
@@ -1,5 +1,6 @@
 <template name="ConnectionSpeedWidget">
 <h1>Connection Speed</h1>
 <h2>{{ country.name }}</h2>
+{{#if byYear}}<h3>{{chosenYear}}</h3>{{/if}}
 <div class="gauge"></div>
 </template>

--- a/packages/connection-speed/client/widget.js
+++ b/packages/connection-speed/client/widget.js
@@ -1,7 +1,7 @@
 Template.ConnectionSpeedWidget.onCreated(function() {
   var template = this;
   template.autorun(function() {
-    template.subscribe('imon_data_v2', Template.currentData().country.code, Settings.indicatorId, true);
+    template.subscribe('imon_data_v2', Template.currentData().country.code, Settings.indicatorId, !Template.currentData().byYear);
     template.subscribe('imon_indicators_v2');
   });
 });
@@ -40,10 +40,13 @@ Template.ConnectionSpeedWidget.onRendered(function() {
   this.autorun(function() {
     if (!template.subscriptionsReady()) { return; }
     var max = IMonIndicators.findOne({ adminName: Settings.indicatorId }).max;
-    var indicator = IMonRecent.findOne({
+    var IMon = Template.currentData().byYear ? IMonData : IMonRecent;
+    var selector = {
         countryCode: Template.currentData().country.code,
         indAdminName: Settings.indicatorId
-    });
+    };
+    if(Template.currentData().byYear){ selector.$where = function(){ return this.date.getFullYear() === Template.currentData().chosenYear; }; }
+    var indicator = IMon.findOne(selector, { sort: { date: -1 } });
     var speedPercent = 0.001;
     if (indicator && getPercent(indicator.value, max) > 0) {
       speedPercent = getPercent(indicator.value, max) * 100;

--- a/packages/connection-speed/connection_speed.js
+++ b/packages/connection-speed/connection_speed.js
@@ -2,13 +2,13 @@ Settings = {
   indicatorName: 'Average connection speed (kbps)',
   indicatorId: 'speedkbps',
   gaugeWidth: 292,
-  defaultCountry: { name: 'United States', code: 'usa' }
+  defaultData: { name: 'United States', code: 'usa', byYear: false, chosenYear: ''}
 };
 
 ConnectionSpeedWidget = function(doc) {
   Widget.call(this, doc);
 
-  _.defaults(this.data, { country: Settings.defaultCountry });
+  _.defaults(this.data, { country: Settings.defaultData });
 };
 
 ConnectionSpeedWidget.prototype = Object.create(Widget.prototype);
@@ -39,7 +39,7 @@ ConnectionSpeed = {
     dimensions: { width: 2, height: 2 },
     category: 'access',
     typeIcon: 'tachometer',
-    constructor: ConnectionSpeedWidget,
+    constructor: ConnectionSpeedWidget
   },
   org: {
     name: 'Akamai Technologies, Inc.',

--- a/packages/imon-barchart/client/widget.css
+++ b/packages/imon-barchart/client/widget.css
@@ -1,27 +1,6 @@
-.imon-scatter .chart-compose, .imon-barchart .chart-compose {
+.imon-barchart .chart-compose {
   border: 0;
 }
-
-.imon-scatter .chart-labels .chart-label {
-  pointer-events: none;
-  visibility: hidden;
-}
-.imon-scatter .chart-label-bg {
-  opacity: 0.5;
-}
-.imon-scatter .chart-labels .chart-label.visible-label {
-  visibility: visible;
-}
-
-.imon-scatter .chart-dots circle {
-  stroke-width: 0;
-}
-
-.imon-scatter .chart-dots circle.selected {
-  fill: #FF6A00 !important;
-  opacity: 1 !important;
-}
-
 
 
 .imon-barchart .barchart-error .alert{

--- a/packages/imon-percent/client/widget.css
+++ b/packages/imon-percent/client/widget.css
@@ -1,7 +1,9 @@
 .imon-percent .fa {
   font-size: 1em;
 }
-
+.imon-percent h2, .imon-percent h3{
+  display:inline;
+}
 .imon-percent h3{
   float: right;
 }

--- a/packages/imon-scatter/imon_scatter.js
+++ b/packages/imon-scatter/imon_scatter.js
@@ -9,7 +9,7 @@ Settings = {
     }
   },
   defaultData: {
-    title: 'Scatter Plot',
+    title: 'Scatterplot',
     byYear: false,
     chosenYear: '',
     x: {

--- a/packages/percent-on-broadband/client/settings.html
+++ b/packages/percent-on-broadband/client/settings.html
@@ -4,17 +4,22 @@
   <label for="country-select">Country</label>
   <select class="country form-control" id="country-select" name="country">
         {{# each countries }}
-        {{> AdoptionOption }}
+ 		 <option value="{{ code }}" {{ isSelected code ../country.code }}>{{ name }}</option>
         {{/each}}
   </select>
 </div>
-
+<div class="form-group">
+  <label for="year-select">Year</label>
+  <select class="year form-control" id="year-select" name="year">
+  		<option value="none" {{ isSelected byYear false }}>Latest available data</option>
+        {{# each year }}
+ 		 <option value="{{ this }}" {{ isSelected this ../chosenYear }}>{{ this }}</option>
+        {{/each}}
+  </select>
+</div>
 <button class="btn btn-primary save-settings">Save</button>
 {{ else }}
   {{ widgetLoading }}
 {{/if}}
 </template>
 
-<template name="AdoptionOption">
-  <option value="{{ code }}" {{ isSelected code ../country.code }}>{{ name }}</option>
-</template>

--- a/packages/percent-on-broadband/client/settings.js
+++ b/packages/percent-on-broadband/client/settings.js
@@ -2,22 +2,36 @@ Template.PercentOnBroadbandSettings.onCreated(function() {
   this.subscribe('imon_countries_v2');
 });
 
+Template.PercentOnBroadbandSettings.onRendered(function(){
+  var template = this;
+  var id = Template.instance().data.widget._id;
+  // Logic here is only for single mode
+  // 1. Initially fill the years
+  var indicator = Settings.indicatorId;
+  Meteor.call('getIndicatorYears', indicator, function(error, result){
+    Session.set(id+'-years', result);
+  });
+});
+
 Template.PercentOnBroadbandSettings.helpers({
+  isSelected: function(a, b) { return a === b ? 'selected' : ''; },  
+  year: function(){ var id = Template.instance().data.widget._id; return Session.get(id+'-years'); },
   countries: function() { return IMonCountries.find({ dataSources: Settings.indicatorId }, { sort: { name: 1 } }); }
 });
 
 Template.PercentOnBroadbandSettings.events({
   'click .save-settings': function(ev, template) {
     var countryCode = template.find('.country').value;
+    var year = template.find('.year').value;
+    var byYear = !(year === 'none');
+    var chosenYear = year === 'none' ? '' : parseInt(year);
     var newData = {
-      country: IMonCountries.findOne({ code: countryCode })
+      country: IMonCountries.findOne({ code: countryCode }),
+      byYear: byYear,
+      chosenYear: chosenYear
     };
     template.closeSettings();
     this.set(newData);
   }
-});
-
-Template.AdoptionOption.helpers({
-  isSelected: function(a, b) { return a === b ? 'selected' : ''; },
 });
 

--- a/packages/percent-on-broadband/client/widget.css
+++ b/packages/percent-on-broadband/client/widget.css
@@ -2,6 +2,14 @@
   font-size: 10px;
 }
 
+.percent-on-broadband h2, .percent-on-broadband h3{
+  display:inline;
+}
+
+.percent-on-broadband h3{
+  float:right;
+}
+
 .percent-on-broadband .fa.online {
   color: #6192BD;
 }

--- a/packages/percent-on-broadband/client/widget.html
+++ b/packages/percent-on-broadband/client/widget.html
@@ -1,6 +1,7 @@
 <template name="PercentOnBroadbandWidget">
   <h1>Broadband Adoption</h1>
   <h2>{{ country.name }}</h2>
+  {{#if byYear}}<h3>{{chosenYear}}</h3>{{/if}}
 {{# if Template.subscriptionsReady }}
   <span class="indicator-value">{{ indicatorValue }}</span>
   <div class="online-users">

--- a/packages/percent-on-broadband/client/widget.js
+++ b/packages/percent-on-broadband/client/widget.js
@@ -1,7 +1,7 @@
 Template.PercentOnBroadbandWidget.onCreated(function() {
   var template = this;
   template.autorun(function() {
-    template.subscribe('imon_data_v2', Template.currentData().country.code, Settings.indicatorId, true);
+    template.subscribe('imon_data_v2', Template.currentData().country.code, Settings.indicatorId, !Template.currentData().byYear);
   });
 });
 

--- a/packages/percent-on-broadband/percent_on_broadband.js
+++ b/packages/percent-on-broadband/percent_on_broadband.js
@@ -1,13 +1,13 @@
 Settings = {
   indicatorName: 'Broadband adoption rate',
   indicatorId: 'bbrate',
-  defaultCountry: { name: 'United States', code: 'usa' }
+  defaultData: { name: 'United States', code: 'usa', byYear: false, chosenYear: '' }
 };
 
 PercentOnBroadbandWidget = function(doc) {
   Widget.call(this, doc);
 
-  _.defaults(this.data, { country: Settings.defaultCountry });
+  _.defaults(this.data, { country: Settings.defaultData });
 };
 
 PercentOnBroadbandWidget.prototype = Object.create(Widget.prototype);
@@ -25,10 +25,11 @@ _.extend(PercentOnBroadbandWidget.prototype, {
     });
   },
   getIndicator: function() {
-    return IMonRecent.findOne({
-      countryCode: this.data.country.code,
-      indAdminName: Settings.indicatorId
-    });
+    var IMon = this.data.byYear ? IMonData : IMonRecent;
+    var chosenYear = this.data.chosenYear;
+    var selector = { countryCode: this.data.country.code, indAdminName: Settings.indicatorId };
+    if(this.data.byYear){ selector.$where = function(){ return this.date.getFullYear() === chosenYear; }; }
+    return IMon.findOne(selector, { sort: { date: -1 } });
   }
 });
 

--- a/packages/percent-online/client/settings.html
+++ b/packages/percent-online/client/settings.html
@@ -9,6 +9,16 @@
   </select>
 </div>
 
+<div class="form-group">
+  <label for="year-select">Year</label>
+  <select class="year form-control" id="year-select" name="year">
+  		<option value="none" {{ isSelected byYear false }}>Latest available data</option>
+        {{# each year }}
+ 		 <option value="{{ this }}" {{ isSelected this ../chosenYear }}>{{ this }}</option>
+        {{/each}}
+  </select>
+</div>
+
 <button class="btn btn-primary save-settings">Save</button>
 {{ else }}
   {{ widgetLoading }}

--- a/packages/percent-online/client/settings.js
+++ b/packages/percent-online/client/settings.js
@@ -2,20 +2,37 @@ Template.PercentOnlineSettings.onCreated(function() {
   this.subscribe('imon_countries_v2');
 });
 
+Template.PercentOnlineSettings.onRendered(function(){
+  var template = this;
+  var id = Template.instance().data.widget._id;
+  // Logic here is only for single mode
+  // 1. Initially fill the years
+  var indicator = Settings.indicatorId;
+  Meteor.call('getIndicatorYears', indicator, function(error, result){
+    Session.set(id+'-years', result);
+  });
+});
+
 Template.PercentOnlineSettings.helpers({
+  year: function(){ var id = Template.instance().data.widget._id; return Session.get(id+'-years'); },
   countries: function() {
     return IMonCountries.find(
         { dataSources: Settings.indicatorId },
         { sort: { name: 1 } });
   },
-  isSelected: function(a, b) { return a === b ? 'selected' : ''; },
+  isSelected: function(a, b) { return a === b ? 'selected' : ''; }
 });
 
 Template.PercentOnlineSettings.events({
   'click .save-settings': function(ev, template) {
     var countryCode = template.find('.country').value;
+    var year = template.find('.year').value;
+    var byYear = !(year === 'none');
+    var chosenYear = year === 'none' ? '' : parseInt(year);
     var newData = {
-      country: IMonCountries.findOne({ code: countryCode })
+      country: IMonCountries.findOne({ code: countryCode }),
+      byYear: byYear,
+      chosenYear: chosenYear
     };
     template.closeSettings();
     this.set(newData);

--- a/packages/percent-online/client/widget.css
+++ b/packages/percent-online/client/widget.css
@@ -22,3 +22,11 @@
   bottom: 20px;
   color: #888;
 }
+
+.percent-online h2, .percent-online h3{
+  display:inline;
+}
+
+.percent-online h3{
+  float:right;
+}

--- a/packages/percent-online/client/widget.html
+++ b/packages/percent-online/client/widget.html
@@ -1,6 +1,7 @@
 <template name="PercentOnlineWidget">
   <h1>Percent Online</h1>
   <h2>{{ country.name }}</h2>
+  {{#if byYear}}<h3>{{chosenYear}}</h3>{{/if}}
 {{# if Template.subscriptionsReady }}
   <span class="indicator-value">{{ indicatorValue }}</span>
   <div class="online-users">

--- a/packages/percent-online/client/widget.js
+++ b/packages/percent-online/client/widget.js
@@ -1,7 +1,7 @@
 Template.PercentOnlineWidget.onCreated(function() {
   var template = this;
   template.autorun(function() {
-    template.subscribe('imon_data_v2', Template.currentData().country.code, Settings.indicatorId, true);
+    template.subscribe('imon_data_v2', Template.currentData().country.code, Settings.indicatorId, !Template.currentData().byYear);
   });
 });
 

--- a/packages/percent-online/percent_online.js
+++ b/packages/percent-online/percent_online.js
@@ -1,13 +1,13 @@
 Settings = {
   indicatorName: 'Percentage of individuals using the Internet',
   indicatorId: 'ipr',
-  defaultCountry: { name: 'United States', code: 'usa' }
+  defaultData: { name: 'United States', code: 'usa', byYear: false, chosenYear: ''}
 };
 
 PercentOnlineWidget = function(doc) {
   Widget.call(this, doc);
 
-  _.defaults(this.data, { country: Settings.defaultCountry });
+  _.defaults(this.data, { country: Settings.defaultData});
 };
 
 PercentOnlineWidget.prototype = Object.create(Widget.prototype);
@@ -25,10 +25,11 @@ _.extend(PercentOnlineWidget.prototype, {
     });
   },
   getIndicator: function() {
-    return IMonRecent.findOne({
-      countryCode: this.data.country.code,
-      indAdminName: Settings.indicatorId
-    });
+    var IMon = this.data.byYear ? IMonData : IMonRecent;
+    var selector = { countryCode: this.data.country.code, indAdminName: Settings.indicatorId };
+    var year = this.data.chosenYear;
+    if(this.data.byYear){ selector.$where = function(){ return this.date.getFullYear()===year; }; }
+    return IMon.findOne(selector, { sort: { date: -1 } });
   }
 });
 


### PR DESCRIPTION
1. Change the position of the year in the percent widget.
2. Change 'Scatter Plot' to 'Scatterplot'
3. Add year selection to `broadband-cost`, `connection-speed`, `percent-online`, and `percent-on-broadband`.

Unresolved issues:
- Long indicator names in y-axis in scatter and barchart do not automatically wrap when too long - user has to increase widget height to view them.
