### PR TITLE
Fix npm request dependency issue in google-trends

### DIFF
--- a/packages/google-trends-map/package.js
+++ b/packages/google-trends-map/package.js
@@ -25,3 +25,5 @@ Package.onUse(function(api) {
     ], 'client');
   api.export('GoogleTrendsMap');
 });
+
+Npm.depends({ 'request': '2.76.0' });


### PR DESCRIPTION
There was an issue with building locally because I didn't have a certain npm package installed, yet it was required in the google-trends-widget. This just declares the dependency in the widget's package.js file.