### PR TITLE
Change Takedown Requests x-axis tick format (#14333)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 apiKey.txt
 public/tmp/*
 settings.json
+packages/*/.npm/**

--- a/packages/lumen/client/widget.js
+++ b/packages/lumen/client/widget.js
@@ -49,7 +49,10 @@ Template.LumenWidget.onRendered(function() {
     var xAxis = d3.svg.axis()
         .scale(x)
         .tickValues(tickValues(binStarts, 3))
-        .tickFormat(function(d) { return moment(d).fromNow(); })
+        .tickFormat(function(d) { 
+          var format = moment().year() === moment(d).year() ? 'MMM Do' : 'MMM Do YY';
+          return moment(d).format(format); 
+        })
         .orient("bottom");
 
     var yAxis = d3.svg.axis()

--- a/packages/lumen/client/widget.js
+++ b/packages/lumen/client/widget.js
@@ -50,7 +50,7 @@ Template.LumenWidget.onRendered(function() {
         .scale(x)
         .tickValues(tickValues(binStarts, 3))
         .tickFormat(function(d) { 
-          var format = moment().year() === moment(d).year() ? 'MMM Do' : 'MMM Do YY';
+          var format = moment().year() === moment(d).year() ? 'MMM Do' : 'MMM Do YYYY';
           return moment(d).format(format); 
         })
         .orient("bottom");


### PR DESCRIPTION
Old format: "X time ago."
Issue: Some tick labels were repeated (and were therefore ambiguous) - "6 months ago, 5 months ago, 5 months ago" for example - because the dates were too close to make a distinction in moment's fromNow() function.
New format: the exact date, like this if it's from the current year: "Apr 7th", and if not: "Apr 7th 2016".