### PR TITLE
Fix spacing of title/subtitle in Bytes Delivered widget (#14365)

### DIFF
--- a/packages/akamaitraffic2/client/widget.css
+++ b/packages/akamaitraffic2/client/widget.css
@@ -5,8 +5,3 @@
 .akamaitraffic2 .label {
   font-weight: 300;
 }
-
-
-.akamaitraffic2 h1 {
-	line-height: 2em;
-}

--- a/packages/akamaitraffic2/client/widget.js
+++ b/packages/akamaitraffic2/client/widget.js
@@ -24,6 +24,7 @@ Template.AkamaiTraffic2Widget.onRendered(function() {
     
     map.draw({
       selector: template.find('.bytes-delivered'),
+      dims: { width: 450, height: 250, scale: 98, squash: 0.90, bumpDown: 30, bumpLeft: 0 },
       data: data,
       iso: 3,
       valueSuffix: '%'


### PR DESCRIPTION
Fix spacing of title/subtitle in Bytes Delivered widget to match the old one.